### PR TITLE
Optional assemblers kmers

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -83,7 +83,7 @@ process {
     withName: 'SEQKIT_STATS' {
         ext.args = '--all'  // add any extra arguments
         publishDir = [
-            path: { "${params.outdir}/R1R2/reads_length/${meta.id}/seqkit" },
+            path: { "${params.outdir}/${meta.reads_type}/reads_length/${meta.id}/seqkit" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -91,7 +91,7 @@ process {
 
     withName: 'GETSEQKITK' {
         publishDir = [
-            path: { "${params.outdir}/R1R2/reads_length/${meta.id}/seqkit" },
+            path: { "${params.outdir}/${meta.reads_type}/reads_length/${meta.id}/seqkit" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -100,7 +100,7 @@ process {
     withName: 'KMERGENIE' {
         ext.args = {"-k ${params.kmergenie_largest_kmer} -l ${params.kmergenie_smallest_kmer}"}
         publishDir = [
-            path: { "${params.outdir}/R1R2/kmergenie/${meta.id}/kmergenie" },
+            path: { "${params.outdir}/${meta.reads_type}/kmergenie/${meta.id}/kmergenie" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -108,7 +108,7 @@ process {
 
     withName: 'GETKMERGENIEK' {
         publishDir = [
-            path: { "${params.outdir}/R1R2/kmergenie/${meta.id}/kmergenie" },
+            path: { "${params.outdir}/${meta.reads_type}/kmergenie/${meta.id}/kmergenie" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -171,7 +171,7 @@ process {
             ].join(' ').trim()
         }
         publishDir = [
-            path: { "${params.outdir}/R1R2/manual/${meta.id}/spades" },
+            path: { "${params.outdir}/${meta.reads_type}/manual/${meta.id}/spades" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -185,7 +185,7 @@ process {
             [kmer_arg, extra].findAll().join(' ').trim()
         }
         publishDir = [
-            path: { "${params.outdir}/R1R2/kmergenie/${meta.id}/spades" },
+            path: { "${params.outdir}/${meta.reads_type}/kmergenie/${meta.id}/spades" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -199,7 +199,7 @@ process {
             [kmer_arg, extra].findAll().join(' ').trim()
         }
         publishDir = [
-            path: { "${params.outdir}/R1R2/reads_length/${meta.id}/spades" },
+            path: { "${params.outdir}/${meta.reads_type}/reads_length/${meta.id}/spades" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -213,7 +213,7 @@ process {
             ].join(' ').trim()
         }
         publishDir = [
-            path: { "${params.outdir}/R1R2/manual/${meta.id}/megahit" },
+            path: { "${params.outdir}/${meta.reads_type}/manual/${meta.id}/megahit" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -227,7 +227,7 @@ process {
             ].join(' ').trim()
         }
         publishDir = [
-            path: { "${params.outdir}/R1R2/kmergenie/${meta.id}/megahit" },
+            path: { "${params.outdir}/${meta.reads_type}/kmergenie/${meta.id}/megahit" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -241,7 +241,7 @@ process {
             ].join(' ').trim()
         }
         publishDir = [
-            path: { "${params.outdir}/R1R2/reads_length/${meta.id}/megahit" },
+            path: { "${params.outdir}/${meta.reads_type}/reads_length/${meta.id}/megahit" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -255,7 +255,7 @@ process {
             ].join(' ').trim()
         }
         publishDir = [
-            path: { "${params.outdir}/R1R2/manual/${meta.id}/minia" },
+            path: { "${params.outdir}/${meta.reads_type}/manual/${meta.id}/minia" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -269,7 +269,7 @@ process {
             ].join(' ').trim()
         }
         publishDir = [
-            path: { "${params.outdir}/R1R2/kmergenie/${meta.id}/minia" },
+            path: { "${params.outdir}/${meta.reads_type}/kmergenie/${meta.id}/minia" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -283,7 +283,7 @@ process {
             ].join(' ').trim()
         }
         publishDir = [
-            path: { "${params.outdir}/R1R2/reads_length/${meta.id}/minia" },
+            path: { "${params.outdir}/${meta.reads_type}/reads_length/${meta.id}/minia" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -296,7 +296,7 @@ process {
             ].join(' ').trim()
         }
         publishDir = [
-            path: { "${params.outdir}/R1R2/manual/${meta.id}/abyss" },
+            path: { "${params.outdir}/${meta.reads_type}/manual/${meta.id}/abyss" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -309,7 +309,7 @@ process {
             ].join(' ').trim()
         }
         publishDir = [
-            path: { "${params.outdir}/R1R2/kmergenie/${meta.id}/abyss" },
+            path: { "${params.outdir}/${meta.reads_type}/kmergenie/${meta.id}/abyss" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -322,7 +322,7 @@ process {
             ].join(' ').trim()
         }
         publishDir = [
-            path: { "${params.outdir}/R1R2/reads_length/${meta.id}/abyss" },
+            path: { "${params.outdir}/${meta.reads_type}/reads_length/${meta.id}/abyss" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -335,7 +335,7 @@ process {
             ].join(' ').trim()
         }
         publishDir = [
-            path: { "${params.outdir}/R1R2/manual/${meta.id}/sparseassembler" },
+            path: { "${params.outdir}/${meta.reads_type}/manual/${meta.id}/sparseassembler" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -348,7 +348,7 @@ process {
             ].join(' ').trim()
         }
         publishDir = [
-            path: { "${params.outdir}/R1R2/kmergenie/${meta.id}/sparseassembler" },
+            path: { "${params.outdir}/${meta.reads_type}/kmergenie/${meta.id}/sparseassembler" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -361,7 +361,7 @@ process {
             ].join(' ').trim()
         }
         publishDir = [
-            path: { "${params.outdir}/R1R2/reads_length/${meta.id}/sparseassembler" },
+            path: { "${params.outdir}/${meta.reads_type}/reads_length/${meta.id}/sparseassembler" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -382,7 +382,7 @@ process {
             ].join(' ').trim()
         }
         publishDir = [
-            path: { "${params.outdir}/R1R2/${meta.kmer_strategy}/${meta.id}/busco_general/${meta.assembler}" },
+            path: { "${params.outdir}/${meta.reads_type}/${meta.kmer_strategy}/${meta.id}/busco_general/${meta.assembler}" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -395,7 +395,7 @@ process {
             ].join(' ').trim()
         }
         publishDir = [
-            path: { "${params.outdir}/R1R2/${meta.kmer_strategy}/${meta.id}/busco_specific/${meta.assembler}" },
+            path: { "${params.outdir}/${meta.reads_type}/${meta.kmer_strategy}/${meta.id}/busco_specific/${meta.assembler}" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -403,7 +403,7 @@ process {
 
     withName: 'MERQURYFK_MERQURYFK' {
         publishDir = [
-            path: { "${params.outdir}/R1R2/${meta.kmer_strategy}/${meta.id}/merquryfk/${meta.assembler}" },
+            path: { "${params.outdir}/${meta.reads_type}/${meta.kmer_strategy}/${meta.id}/merquryfk/${meta.assembler}" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]

--- a/modules.json
+++ b/modules.json
@@ -7,37 +7,37 @@
                 "nf-core": {
                     "abyss/abysspe": {
                         "branch": "master",
-                        "git_sha": "380cb90926b8c28558cb11479da5ff45bc4f1c5d",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "busco/busco": {
                         "branch": "master",
-                        "git_sha": "d1c0b25085d275521d7b3d91120a6e797ace83d4",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "falco": {
                         "branch": "master",
-                        "git_sha": "b2f164ca59b14d6e9ed2dd2a99fa015085396faf",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "fastk/fastk": {
                         "branch": "master",
-                        "git_sha": "4a2e3a7b7af922aa5b94b00c2e78175be15787a2",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "fastk/histex": {
                         "branch": "master",
-                        "git_sha": "1838663f8c38ccd7833be0df0e53a26b7c72b567",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "fastp": {
                         "branch": "master",
-                        "git_sha": "1fb5a73bce8e4ac7079b0a9461b23d11e877ad14",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "fcsgx/rungx": {
                         "branch": "master",
-                        "git_sha": "0f69cb9d85f8d5ae9f7db0850e583c83b9a391d2",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "genescopefk": {
@@ -47,47 +47,47 @@
                     },
                     "kmergenie": {
                         "branch": "master",
-                        "git_sha": "a035704d396cf4a22a8e28dfc9b3b371cf1aef05",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "megahit": {
                         "branch": "master",
-                        "git_sha": "e4f18d1cecc86b39daafe8bf22343b868e696c15",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "merquryfk/merquryfk": {
                         "branch": "master",
-                        "git_sha": "1838663f8c38ccd7833be0df0e53a26b7c72b567",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "minia": {
                         "branch": "master",
-                        "git_sha": "e65056da8e7247487aaecd078b07d7fd68080a78",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "multiqc": {
                         "branch": "master",
-                        "git_sha": "79b36b51048048374b642289bfe9e591ef56fe05",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "quast": {
                         "branch": "master",
-                        "git_sha": "c3ef6747c66c2d6217d067fd2dfb3412ff46bc3e",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "seqkit/stats": {
                         "branch": "master",
-                        "git_sha": "bf70cbf44b42ff4a81afcb673fcef604f5ef3a85",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "spades": {
                         "branch": "master",
-                        "git_sha": "eeeb609bd37db7d81d7f6cb7d23a73c08ac4d752",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "tiara/tiara": {
                         "branch": "master",
-                        "git_sha": "240b2ee57d7cefbb276315d178285398bdb34c2f",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     }
                 }

--- a/modules/nf-core/abyss/abysspe/main.nf
+++ b/modules/nf-core/abyss/abysspe/main.nf
@@ -3,9 +3,9 @@ process ABYSS_ABYSSPE {
     label 'process_high'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/abyss:2.3.10--hf316886_1':
-        'biocontainers/abyss:2.3.10--hf316886_1' }"
+        'quay.io/biocontainers/abyss:2.3.10--hf316886_1' }"
 
     input:
     tuple val(meta), path(reads), path(merged)

--- a/modules/nf-core/busco/busco/main.nf
+++ b/modules/nf-core/busco/busco/main.nf
@@ -3,7 +3,7 @@ process BUSCO_BUSCO {
     label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
         ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/c6/c6684133dafc676a4087ca5615907bfdaaba29210f1c8eb2082c4096a009b2cd/data'
         : 'community.wave.seqera.io/library/busco_numpy:1877b1d6022fa08d'}"
     // Note: one test had to be disabled when switching to Busco 6.0.0, cf https://github.com/nf-core/modules/pull/8781/files

--- a/modules/nf-core/falco/main.nf
+++ b/modules/nf-core/falco/main.nf
@@ -3,9 +3,9 @@ process FALCO {
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
         ? 'https://depot.galaxyproject.org/singularity/falco:1.2.5--h077b44d_0'
-        : 'biocontainers/falco:1.2.5--h077b44d_0'}"
+        : 'quay.io/biocontainers/falco:1.2.5--h077b44d_0'}"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/fastk/fastk/main.nf
+++ b/modules/nf-core/fastk/fastk/main.nf
@@ -4,7 +4,7 @@ process FASTK_FASTK {
 
     // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/02/02c05b2ec421debc83883ef9a211291e3220546c12f7c54cb78e66209cb2797d/data' :
         'community.wave.seqera.io/library/fastk:1.2--4bc70c6cd0d420bd' }"
 

--- a/modules/nf-core/fastk/histex/main.nf
+++ b/modules/nf-core/fastk/histex/main.nf
@@ -4,7 +4,7 @@ process FASTK_HISTEX {
 
     // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/02/02c05b2ec421debc83883ef9a211291e3220546c12f7c54cb78e66209cb2797d/data' :
         'community.wave.seqera.io/library/fastk:1.2--4bc70c6cd0d420bd' }"
 

--- a/modules/nf-core/fastp/main.nf
+++ b/modules/nf-core/fastp/main.nf
@@ -3,7 +3,7 @@ process FASTP {
     label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/55/556474e164daf5a5e218cd5d497681dcba0645047cf24698f88e3e078eacbd09/data' :
         'community.wave.seqera.io/library/fastp:1.1.0--08aa7c5662a30d57' }"
 

--- a/modules/nf-core/fcsgx/rungx/main.nf
+++ b/modules/nf-core/fcsgx/rungx/main.nf
@@ -3,9 +3,9 @@ process FCSGX_RUNGX {
     label 'process_high'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/ncbi-fcs-gx:0.5.5--h9948957_0':
-        'biocontainers/ncbi-fcs-gx:0.5.5--h9948957_0' }"
+        'quay.io/biocontainers/ncbi-fcs-gx:0.5.5--h9948957_0' }"
 
     input:
     tuple val(meta), val(taxid), path(fasta)

--- a/modules/nf-core/kmergenie/main.nf
+++ b/modules/nf-core/kmergenie/main.nf
@@ -3,7 +3,7 @@ process KMERGENIE {
     label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/5f/5f4197eec51307131e6cb0170a7969eda60995b23942d050f7495dc4a530b118/data':
         'community.wave.seqera.io/library/kmergenie:1.7051--675dfe5a4c7ea92b' }"
 

--- a/modules/nf-core/megahit/main.nf
+++ b/modules/nf-core/megahit/main.nf
@@ -2,7 +2,7 @@ process MEGAHIT {
     tag "${meta.id}"
     label 'process_high'
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/f2/f2cb827988dca7067ff8096c37cb20bc841c878013da52ad47a50865d54efe83/data' :
         'community.wave.seqera.io/library/megahit_pigz:87a590163e594224' }"
 

--- a/modules/nf-core/merquryfk/merquryfk/main.nf
+++ b/modules/nf-core/merquryfk/merquryfk/main.nf
@@ -3,7 +3,7 @@ process MERQURYFK_MERQURYFK {
     label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/56/56641ad3d1130e668134edc752fdf0bed1cc31da3b3d74730aa6edf40527493a/data' :
         'community.wave.seqera.io/library/merquryfk:1.2--f21b6c1cbbbbfe64' }"
 

--- a/modules/nf-core/minia/main.nf
+++ b/modules/nf-core/minia/main.nf
@@ -3,7 +3,7 @@ process MINIA {
     label 'process_high'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/40/40a4c0032d52284f76044828f50750948f2717e63f084e1ea80f6bd068b65b25/data' :
         'community.wave.seqera.io/library/minia:3.2.6--df502ab09998dab4' }"
 

--- a/modules/nf-core/multiqc/main.nf
+++ b/modules/nf-core/multiqc/main.nf
@@ -3,7 +3,7 @@ process MULTIQC {
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
         ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/34/34e733a9ae16a27e80fe00f863ea1479c96416017f24a907996126283e7ecd4d/data'
         : 'community.wave.seqera.io/library/multiqc:1.33--ee7739d47738383b'}"
 

--- a/modules/nf-core/quast/main.nf
+++ b/modules/nf-core/quast/main.nf
@@ -3,7 +3,7 @@ process QUAST {
     label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/a5/a515d04307ea3e0178af75132105cd36c87d0116c6f9daecf81650b973e870fd/data' :
         'community.wave.seqera.io/library/quast:5.3.0--755a216045b6dbdd' }"
 

--- a/modules/nf-core/seqkit/stats/main.nf
+++ b/modules/nf-core/seqkit/stats/main.nf
@@ -3,9 +3,9 @@ process SEQKIT_STATS {
     label 'process_low'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
         ? 'https://depot.galaxyproject.org/singularity/seqkit:2.9.0--h9ee0642_0'
-        : 'biocontainers/seqkit:2.9.0--h9ee0642_0'}"
+        : 'quay.io/biocontainers/seqkit:2.9.0--h9ee0642_0'}"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/spades/main.nf
+++ b/modules/nf-core/spades/main.nf
@@ -3,7 +3,7 @@ process SPADES {
     label 'process_high'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/7b/7b7b68c7f8471d9111841dbe594c00a41cdd3b713015c838c4b22705cfbbdfb2/data' :
         'community.wave.seqera.io/library/spades:4.1.0--77799c52e1d1054a' }"
 

--- a/modules/nf-core/tiara/tiara/main.nf
+++ b/modules/nf-core/tiara/tiara/main.nf
@@ -4,7 +4,7 @@ process TIARA_TIARA {
 
     // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
         ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/e5/e5909e63835fda5723b1408001568a306e234dd0035b3518af8a8930625e449d/data'
         : 'community.wave.seqera.io/library/tiara:1.0.3--e367cb0eaef39fa3'}"
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -47,11 +47,17 @@ params {
     histex_g_output            = true // add -G to output full histogram format for GeneScopeFK
     histex_extra_args          = '' // additional Histex args
 
+    // k-mer strategy options
+    skip_manual_strategy       = false // whether to skip manual k-mer strategy selection and use the default k-mer strategy
+    skip_kmergenie_strategy     = false // whether to skip Kmergenie strategy selection and use the default k-mer strategy
+    skip_reads_length_strategy   = false // whether to skip read length strategy selection and use the default k-mer strategy
+
     // Kmergenie options
     kmergenie_largest_kmer     = 121 // largest k-mer size to consider (default: 121)
     kmergenie_smallest_kmer    = 15  // smallest k-mer size to consider (default: 15)
 
     // Spades options
+    skip_spades                  = false // whether to skip SPAdes assembly
     spades_kmer_list           = 'auto' // list of k-mer sizes (must be odd and less than 128) [default: 'auto']
     spades_extra_args          = '--only-assembler' // add here any extra  param
 
@@ -78,7 +84,7 @@ params {
     busco_mode                 = 'genome'
     busco_lineage              = 'fungi_odb12'
     busco_db_extension         = 'odb12'
-    lineages_list_file         = 'data/fungi_busco_lineages.txt'
+    lineages_list_file         = null
     busco_lineages_path        = null
     busco_config_file          = null
     busco_clean_intermediates  = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -62,18 +62,22 @@ params {
     spades_extra_args          = '--only-assembler' // add here any extra  param
 
     // Megahit options
+    skip_megahit               = false // whether to skip MEGAHIT assembly
     megahit_kmer_list          = '21,29,39,59,79,99,119,141' // comma-separated list of kmer size all must be odd, in the range 15-255, increment <= 28 [21,29,39,59,79,99,119,141]
     megahit_extra_args         = '--no-mercy --min-count 3'
 
     // Minia options
+    skip_minia                 = false // whether to skip Minia assembly
     minia_kmer                 = 21
     minia_extra_args           = null
 
     // Abyss options
+    skip_abyss                 = false // whether to skip Abyss assembly
     abyss_kmer                 = 21
     abyss_extra_args           = null
 
     // SparseAssembler options
+    skip_sparseassembler               = false // whether to skip SparseAssembler assembly
     sparseassembler_kmer               = 21
     sparseassembler_genome_size        = 150000000
     sparseassembler_scaffold           = 1
@@ -84,8 +88,8 @@ params {
     busco_mode                 = 'genome'
     busco_lineage              = 'fungi_odb12'
     busco_db_extension         = 'odb12'
-    lineages_list_file         = null
-    busco_lineages_path        = null
+    lineages_list_file         = 'data/fungi_busco_lineages.txt'
+    busco_lineages_path        = '/home/lia/git_repos/fspassemblypipeline/data'
     busco_config_file          = null
     busco_clean_intermediates  = false
     busco_extra_args           = '--offline'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -265,8 +265,7 @@
             "type": ["string", "null"]
         },
         "fastp_extra_args": {
-            "type": ["string", "null"],
-            "default": null
+            "type": ["string", "null"]
         },
         "fastk_kmer": {
             "type": "integer",
@@ -285,16 +284,14 @@
             "default": true
         },
         "fastk_extra_args": {
-            "type": ["string", "null"],
-            "default": null
+            "type": ["string", "null"]
         },
         "histex_g_output": {
             "type": "boolean",
             "default": true
         },
         "histex_extra_args": {
-            "type": ["string", "null"],
-            "default": null
+            "type": ["string", "null"]
         },
         "spades_kmer_list": {
             "type": "string",
@@ -312,12 +309,12 @@
             "type": "string",
             "default": "--no-mercy --min-count 3"
         },
+        "minia_extra_args": {
+            "type": "string"
+        },
         "minia_kmer": {
             "type": "integer",
             "default": 21
-        },
-        "minia_extra_args": {
-            "type": "string"
         },
         "busco_mode": {
             "type": "string",
@@ -391,8 +388,19 @@
             "default": "odb12"
         },
         "lineages_list_file": {
-            "type": "string",
-            "default": "data/fungi_busco_lineages.txt"
+            "type": "string"
+        },
+        "skip_manual_strategy": {
+            "type": "boolean"
+        },
+        "skip_kmergenie_strategy": {
+            "type": "boolean"
+        },
+        "skip_reads_length_strategy": {
+            "type": "boolean"
+        },
+        "skip_spades": {
+            "type": "boolean"
         }
     }
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -401,6 +401,18 @@
         },
         "skip_spades": {
             "type": "boolean"
+        },
+        "skip_megahit": {
+            "type": "boolean"
+        },
+        "skip_minia": {
+            "type": "boolean"
+        },
+        "skip_abyss": {
+            "type": "boolean"
+        },
+        "skip_sparseassembler": {
+            "type": "boolean"
         }
     }
 }

--- a/subworkflows/local/genome_assembly/main.nf
+++ b/subworkflows/local/genome_assembly/main.nf
@@ -42,13 +42,13 @@ workflow GENOME_ASSEMBLY {
 
 // ==================== K-mer strategies for genome assembly =======================
 
-    def ch_reads_manual_strategy = channel.empty()
-    def ch_reads_kmergenie_strategy = channel.empty()
-    def ch_reads_reads_length_strategy = channel.empty()
+    def ch_manual_strategy = channel.empty()
+    def ch_kmergenie_strategy = channel.empty()
+    def ch_reads_length_strategy = channel.empty()
 
     // Channel 1: Manual strategy (uses config values)
     if (!params.skip_manual_strategy) {
-        ch_reads_manual_strategy = ch_paired_reads
+        ch_manual_strategy = ch_paired_reads
             .map { meta, reads ->
                 [meta + [kmer_strategy: 'manual'], reads]
             }
@@ -69,7 +69,7 @@ workflow GENOME_ASSEMBLY {
         ch_kmergenie_html = KMERGENIE.out.html
         ch_getkmergeniek_k = GETKMERGENIEK.out.kmer_txt
 
-        ch_reads_kmergenie_strategy = ch_paired_reads
+        ch_kmergenie_strategy = ch_paired_reads
             .map { meta, reads -> [meta.id, meta, reads] }
             .join(GETKMERGENIEK.out.kmer_txt.map { meta, kmer_file ->
                 [meta.id, kmer_file.text.trim() as Integer]
@@ -136,7 +136,7 @@ workflow GENOME_ASSEMBLY {
         ch_seqkit_stats = SEQKIT_STATS.out.stats
         ch_getseqkitk_kmer = GETSEQKITK.out.seqkitkmer_txt
 
-        ch_reads_reads_length_strategy = ch_paired_reads
+        ch_reads_length_strategy = ch_paired_reads
             .map { meta, reads -> [meta.id, meta, reads] }
             .join(GETSEQKITK.out.seqkitkmer_txt.map { meta, kmer_file ->
                 [meta.id, kmer_file.text.trim() as Integer]
@@ -203,7 +203,7 @@ workflow GENOME_ASSEMBLY {
     }
 
     // Create channel with new meta for downstream processes (after assembly). This channel combines all assemblies from different assemblers and strategies, and maps them to the new meta with updated id.
-    def ch_draft_assemblies_input = Channel.empty()
+    def ch_draft_assemblies_input = channel.empty()
 
     // ======= Spades assemblies - nested conditionals (assembler × strategy) ======
     // Spades is only run if skip_spades is false. Within that, each strategy is only run if its corresponding skip parameter is false.
@@ -211,22 +211,15 @@ workflow GENOME_ASSEMBLY {
     // Spades needs a tuple with 4 elements as inputs, so we need to map the channel to add empty lists for the other 2 inputs (see PREPROCESSING subworkflow for example)
     // SPADES: [ meta, illumina, pacbio, nanopore ]
 
-
-    // Initialise channels for outputs as empty to avoid use of conditionals in emit section.
-    def ch_spades_scaffolds_manual = channel.empty()
-    def ch_spades_scaffolds_kmergenie = channel.empty()
-    def ch_spades_scaffolds_reads_length = channel.empty()
-
     if (!params.skip_spades) {
 
         if (!params.skip_manual_strategy) {
             SPADES_MANUAL(
-                ch_reads_manual_strategy.map { meta, reads -> [meta, reads, [], []] },
+                ch_manual_strategy.map { meta, reads -> [meta, reads, [], []] },
                 [],
                 []
             )
-            // Capture output for emits (avoids using conditionals in emits section)
-            ch_spades_scaffolds_manual = SPADES_MANUAL.out.scaffolds
+
             // Mix into draft assemblies channel with new meta
             ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
                 SPADES_MANUAL.out.scaffolds
@@ -236,13 +229,10 @@ workflow GENOME_ASSEMBLY {
 
         if (!params.skip_kmergenie_strategy) {
             SPADES_KMERGENIE(
-                ch_reads_kmergenie_strategy.map { meta, reads -> [meta, reads, [], []] },
+                ch_kmergenie_strategy.map { meta, reads -> [meta, reads, [], []] },
                 [],
                 []
             )
-
-            // Capture output for emits (avoids using conditionals in emits section)
-            ch_spades_scaffolds_kmergenie = SPADES_KMERGENIE.out.scaffolds
 
             // Mix into draft assemblies channel with new meta
             ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
@@ -253,13 +243,10 @@ workflow GENOME_ASSEMBLY {
 
         if (!params.skip_reads_length_strategy) {
             SPADES_READS_LENGTH(
-                ch_reads_reads_length_strategy.map { meta, reads -> [meta, reads, [], []] },
+                ch_reads_length_strategy.map { meta, reads -> [meta, reads, [], []] },
                 [],
                 []
             )
-
-            // Capture output for emits (avoids using conditionals in emits section)
-            ch_spades_scaffolds_reads_length = SPADES_READS_LENGTH.out.scaffolds
 
             // Mix into draft assemblies channel with new meta
             ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
@@ -275,20 +262,11 @@ workflow GENOME_ASSEMBLY {
     // Megahit needs a tuple with 3 elements as input. I can't use ch_paired_reads directly because R1 and R2 paths there are in a single list element. So I need to map the channel to split R1 and R2 into separate list elements.
     // MEGAHIT: [ meta, reads1, reads2 ]
 
-
-    // Initialise channels for outputs as empty to avoid use of conditionals in emit section.
-    def ch_megahit_contigs_manual = channel.empty()
-    def ch_megahit_contigs_kmergenie = channel.empty()
-    def ch_megahit_contigs_reads_length = channel.empty()
-
     if (!params.skip_megahit) {
 
         if (!params.skip_manual_strategy) {
-            ch_megahit_input_manual = ch_reads_manual_strategy.map { meta, reads -> [meta, reads[0], reads[1]] }
+            ch_megahit_input_manual = ch_manual_strategy.map { meta, reads -> [meta, reads[0], reads[1]] }
             MEGAHIT_MANUAL(ch_megahit_input_manual)
-
-            // Capture output for emits (avoids using conditionals in emits section)
-            ch_megahit_contigs_manual = MEGAHIT_MANUAL.out.contigs
 
             // Mix into draft assemblies channel with new meta
             ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
@@ -297,11 +275,8 @@ workflow GENOME_ASSEMBLY {
         }
 
         if (!params.skip_kmergenie_strategy) {
-            ch_megahit_input_kmergenie = ch_reads_kmergenie_strategy.map { meta, reads -> [ meta, reads[0], reads[1] ] }
+            ch_megahit_input_kmergenie = ch_kmergenie_strategy.map { meta, reads -> [ meta, reads[0], reads[1] ] }
             MEGAHIT_KMERGENIE(ch_megahit_input_kmergenie)
-
-            // Capture output for emits (avoids using conditionals in emits section)
-            ch_megahit_contigs_kmergenie = MEGAHIT_KMERGENIE.out.contigs
 
             // Mix into draft assemblies channel with new meta
             ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
@@ -310,11 +285,8 @@ workflow GENOME_ASSEMBLY {
         }
 
         if (!params.skip_reads_length_strategy) {
-            ch_megahit_input_reads_length = ch_reads_reads_length_strategy.map { meta, reads -> [ meta, reads[0], reads[1] ] }
+            ch_megahit_input_reads_length = ch_reads_length_strategy.map { meta, reads -> [ meta, reads[0], reads[1] ] }
             MEGAHIT_READS_LENGTH(ch_megahit_input_reads_length)
-
-            // Capture output for emits (avoids using conditionals in emits section)
-            ch_megahit_contigs_reads_length = MEGAHIT_READS_LENGTH.out.contigs
 
             // Mix into draft assemblies channel with new meta
             ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
@@ -327,18 +299,10 @@ workflow GENOME_ASSEMBLY {
     // Minia is only run if skip_minia is false. Within that, each strategy is only run if its corresponding skip parameter is false.
     // The channel with Minia assemblies is populated accordingly and mixed into the common ch_draft_assemblies_input channel.
 
-    // Initialise channels for outputs as empty to avoid use of conditionals in emit section.
-    def ch_minia_contigs_manual = channel.empty()
-    def ch_minia_contigs_kmergenie = channel.empty()
-    def ch_minia_contigs_reads_length = channel.empty()
-
     if (!params.skip_minia) {
 
         if (!params.skip_manual_strategy) {
-            MINIA_MANUAL(ch_reads_manual_strategy)
-
-            // Capture output for emits (avoids using conditionals in emits section)
-            ch_minia_contigs_manual = MINIA_MANUAL.out.contigs
+            MINIA_MANUAL(ch_manual_strategy)
 
             // Mix into draft assemblies channel with new meta
             ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
@@ -347,10 +311,7 @@ workflow GENOME_ASSEMBLY {
         }
 
         if (!params.skip_kmergenie_strategy) {
-            MINIA_KMERGENIE(ch_reads_kmergenie_strategy)
-
-            // Capture output for emits (avoids using conditionals in emits section)
-            ch_minia_contigs_kmergenie = MINIA_KMERGENIE.out.contigs
+            MINIA_KMERGENIE(ch_kmergenie_strategy)
 
             // Mix into draft assemblies channel with new meta
             ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
@@ -359,10 +320,7 @@ workflow GENOME_ASSEMBLY {
         }
 
         if (!params.skip_reads_length_strategy) {
-            MINIA_READS_LENGTH(ch_reads_reads_length_strategy)
-
-            // Capture output for emits (avoids using conditionals in emits section)
-            ch_minia_contigs_reads_length = MINIA_READS_LENGTH.out.contigs
+            MINIA_READS_LENGTH(ch_reads_length_strategy)
 
             // Mix into draft assemblies channel with new meta
             ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
@@ -375,19 +333,11 @@ workflow GENOME_ASSEMBLY {
     // ABYSS is only run if skip_abyss is false. Within that, each strategy is only run if its corresponding skip parameter is false.
     // The channel with ABYSS assemblies is populated accordingly and mixed into the common ch_draft_assemblies_input channel.
 
-    // Initialise channels for outputs as empty to avoid use of conditionals in emit section.
-    def ch_abyss_scaffolds_manual = channel.empty()
-    def ch_abyss_scaffolds_kmergenie = channel.empty()
-    def ch_abyss_scaffolds_reads_length = channel.empty()
-
     if (!params.skip_abyss) {
 
         if (!params.skip_manual_strategy) {
-            ch_abyss_input_manual = ch_reads_manual_strategy.map { meta, reads -> [ meta, reads, [] ] }
+            ch_abyss_input_manual = ch_manual_strategy.map { meta, reads -> [ meta, reads, [] ] }
             ABYSS_MANUAL(ch_abyss_input_manual, params.abyss_kmer)
-
-            // Capture output for emits (avoids using conditionals in emits section)
-            ch_abyss_scaffolds_manual = ABYSS_MANUAL.out.scaffolds
 
             // Mix into draft assemblies channel with new meta
             ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
@@ -396,13 +346,14 @@ workflow GENOME_ASSEMBLY {
         }
 
         if (!params.skip_kmergenie_strategy) {
-            // Create k-mer channel for ABYSS (needs single kmer value)
-            ch_abyss_kmergenie_single_kmer = ch_reads_kmergenie_strategy.map { meta, reads -> meta.single_kmer }
-            ch_abyss_input_kmergenie = ch_reads_kmergenie_strategy.map { meta, reads -> [ meta, reads, [] ] }
-            ABYSS_KMERGENIE(ch_abyss_input_kmergenie, ch_abyss_kmergenie_single_kmer)
+            // Create k-mer channel for ABYSS (needs single kmer value) using multiMap
+            ch_abyss_kmergenie = ch_kmergenie_strategy
+                .multiMap { meta, reads ->
+                    input:      [ meta, reads, [] ]
+                    single_kmer: meta.single_kmer
+                }
 
-            // Capture output for emits (avoids using conditionals in emits section)
-            ch_abyss_scaffolds_kmergenie = ABYSS_KMERGENIE.out.scaffolds
+            ABYSS_KMERGENIE(ch_abyss_kmergenie.input, ch_abyss_kmergenie.single_kmer)
 
             // Mix into draft assemblies channel with new meta
             ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
@@ -411,13 +362,14 @@ workflow GENOME_ASSEMBLY {
         }
 
         if (!params.skip_reads_length_strategy) {
-            // Create k-mer channel for ABYSS (needs single kmer value)
-            ch_abyss_reads_length_single_kmer = ch_reads_reads_length_strategy.map { meta, reads -> meta.single_kmer }
-            ch_abyss_input_reads_length = ch_reads_reads_length_strategy.map { meta, reads -> [ meta, reads, [] ] }
-            ABYSS_READS_LENGTH(ch_abyss_input_reads_length, ch_abyss_reads_length_single_kmer)
+            // Create k-mer channel for ABYSS (needs single kmer value) using multiMap
+            ch_abyss_reads_length = ch_reads_length_strategy
+                .multiMap { meta, reads ->
+                    input:      [ meta, reads, [] ]
+                    single_kmer: meta.single_kmer
+                }
 
-            // Capture output for emits (avoids using conditionals in emits section)
-            ch_abyss_scaffolds_reads_length = ABYSS_READS_LENGTH.out.scaffolds
+            ABYSS_READS_LENGTH(ch_abyss_reads_length.input, ch_abyss_reads_length.single_kmer)
 
             // Mix into draft assemblies channel with new meta
             ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
@@ -431,27 +383,15 @@ workflow GENOME_ASSEMBLY {
     // The channel with SPARSEASSEMBLER assemblies is populated accordingly and mixed into the common ch_draft_assemblies_input channel.
     // SPARSEASSEMBLER is a special case because it can output contigs or scaffolds depending on the parameters used and quality of the reads
 
-    // Initialise channels for outputs as empty to avoid use of conditionals in emit section.
-    def ch_sparseassembler_scaffolds_manual = channel.empty()
-    def ch_sparseassembler_contigs_manual = channel.empty()
-    def ch_sparseassembler_scaffolds_kmergenie = channel.empty()
-    def ch_sparseassembler_contigs_kmergenie = channel.empty()
-    def ch_sparseassembler_scaffolds_reads_length = channel.empty()
-    def ch_sparseassembler_contigs_reads_length = channel.empty()
-
     if (!params.skip_sparseassembler) {
 
         if (!params.skip_manual_strategy) {
             SPARSEASSEMBLER_MANUAL(
-                ch_reads_manual_strategy,
+                ch_manual_strategy,
                 params.sparseassembler_kmer,
                 params.sparseassembler_genome_size,
                 params.sparseassembler_expected_coverage
             )
-
-            // Capture output for emits (avoids using conditionals in emits section)
-            ch_sparseassembler_scaffolds_manual = SPARSEASSEMBLER_MANUAL.out.scaffolds
-            ch_sparseassembler_contigs_manual = SPARSEASSEMBLER_MANUAL.out.contigs
 
             // Mix into draft assemblies channel with new meta
             ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
@@ -463,18 +403,19 @@ workflow GENOME_ASSEMBLY {
         }
 
         if (!params.skip_kmergenie_strategy) {
-            // Create k-mer channel for SPARSEASSEMBLER (needs single kmer value)
-            ch_sparseassembler_kmergenie_single_kmer = ch_reads_kmergenie_strategy.map { meta, reads -> meta.single_kmer }
+            // Create k-mer channel for SPARSEASSEMBLER (needs single kmer value) using multiMap
+            ch_sparseassembler_kmergenie = ch_kmergenie_strategy
+                .multiMap { meta, reads ->
+                    input:       [ meta, reads ]
+                    single_kmer: meta.single_kmer
+                }
+
             SPARSEASSEMBLER_KMERGENIE(
-                ch_reads_kmergenie_strategy,
-                ch_sparseassembler_kmergenie_single_kmer,
+                ch_sparseassembler_kmergenie.input,
+                ch_sparseassembler_kmergenie.single_kmer,
                 params.sparseassembler_genome_size,
                 params.sparseassembler_expected_coverage
             )
-
-            // Capture output for emits (avoids using conditionals in emits section)
-            ch_sparseassembler_scaffolds_kmergenie = SPARSEASSEMBLER_KMERGENIE.out.scaffolds
-            ch_sparseassembler_contigs_kmergenie = SPARSEASSEMBLER_KMERGENIE.out.contigs
 
             // Mix into draft assemblies channel with new meta
             ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
@@ -486,18 +427,19 @@ workflow GENOME_ASSEMBLY {
         }
 
         if (!params.skip_reads_length_strategy) {
-            // Create k-mer channel for SPARSEASSEMBLER (needs single kmer value)
-            ch_sparseassembler_reads_length_single_kmer = ch_reads_reads_length_strategy.map { meta, reads -> meta.single_kmer }
+            // Create k-mer channel for SPARSEASSEMBLER (needs single kmer value) using multiMap
+            ch_sparseassembler_reads_length = ch_reads_length_strategy
+                .multiMap { meta, reads ->
+                    input:       [ meta, reads ]
+                    single_kmer: meta.single_kmer
+                }
+
             SPARSEASSEMBLER_READS_LENGTH(
-                ch_reads_reads_length_strategy,
-                ch_sparseassembler_reads_length_single_kmer,
+                ch_sparseassembler_reads_length.input,
+                ch_sparseassembler_reads_length.single_kmer,
                 params.sparseassembler_genome_size,
                 params.sparseassembler_expected_coverage
             )
-
-            // Capture output for emits (avoids using conditionals in emits section)
-            ch_sparseassembler_scaffolds_reads_length = SPARSEASSEMBLER_READS_LENGTH.out.scaffolds
-            ch_sparseassembler_contigs_reads_length = SPARSEASSEMBLER_READS_LENGTH.out.contigs
 
             // Mix into draft assemblies channel with new meta
             ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
@@ -595,34 +537,6 @@ workflow GENOME_ASSEMBLY {
     getseqkitk_kmer                             = ch_getseqkitk_kmer
     kmergenie_html                              = ch_kmergenie_html
     getkmergeniek_k                             = ch_getkmergeniek_k
-
-    // SPAdes outputs
-    spades_scaffolds_manual                     = ch_spades_scaffolds_manual
-    spades_scaffolds_kmergenie                  = ch_spades_scaffolds_kmergenie
-    spades_scaffolds_reads_length               = ch_spades_scaffolds_reads_length
-
-    // MEGAHIT outputs
-    megahit_contigs_manual                      = ch_megahit_contigs_manual
-    megahit_contigs_kmergenie                   = ch_megahit_contigs_kmergenie
-    megahit_contigs_reads_length                = ch_megahit_contigs_reads_length
-
-    // Minia outputs
-    minia_contigs_manual                        = ch_minia_contigs_manual
-    minia_contigs_kmergenie                     = ch_minia_contigs_kmergenie
-    minia_contigs_reads_length                  = ch_minia_contigs_reads_length
-
-    // ABySS outputs
-    abyss_scaffolds_manual                      = ch_abyss_scaffolds_manual
-    abyss_scaffolds_kmergenie                   = ch_abyss_scaffolds_kmergenie
-    abyss_scaffolds_reads_length                = ch_abyss_scaffolds_reads_length
-
-    // SparseAssembler outputs
-    sparseassembler_scaffolds_manual            = ch_sparseassembler_scaffolds_manual
-    sparseassembler_contigs_manual              = ch_sparseassembler_contigs_manual
-    sparseassembler_scaffolds_kmergenie         = ch_sparseassembler_scaffolds_kmergenie
-    sparseassembler_contigs_kmergenie           = ch_sparseassembler_contigs_kmergenie
-    sparseassembler_scaffolds_reads_length      = ch_sparseassembler_scaffolds_reads_length
-    sparseassembler_contigs_reads_length        = ch_sparseassembler_contigs_reads_length
 
     // Downstream outputs (unconditional processes)
     renamed_assemblies                          = RENAME_ASSEMBLIES.out.renamed_assemblies

--- a/subworkflows/local/genome_assembly/main.nf
+++ b/subworkflows/local/genome_assembly/main.nf
@@ -32,184 +32,138 @@ workflow GENOME_ASSEMBLY {
 
     main:
 
-    SEQKIT_STATS ( ch_fastp_reads )
-    GETSEQKITK   ( SEQKIT_STATS.out.stats )
-//    SEQKIT_STATS_MERGED
     FASTK_FASTK  ( ch_fastp_reads )
-
-    KMERGENIE    ( ch_fastp_reads )
-
-    GETKMERGENIEK ( KMERGENIE.out.html )
 
 // ==================== K-mer strategies for genome assembly =======================
 
+    def ch_reads_manual_strategy = Channel.empty()
+    def ch_reads_kmergenie_strategy = Channel.empty()
+    def ch_reads_reads_length_strategy = Channel.empty()
+
     // Channel 1: Manual strategy (uses config values)
-    ch_reads_manual_strategy = ch_fastp_reads
-        .map { meta, reads ->
-            [meta + [kmer_strategy: 'manual'], reads]
-        }
-
+    if (!params.skip_manual_strategy) {
+        ch_reads_manual_strategy = ch_fastp_reads
+            .map { meta, reads ->
+                [meta + [kmer_strategy: 'manual'], reads]
+            }
+    }
     // Channel 2: KmerGenie strategy (adds predicted kmer to default list)
-    ch_reads_kmergenie_strategy = ch_fastp_reads
-        .map { meta, reads -> [meta.id, meta, reads] }
-        .join(GETKMERGENIEK.out.kmer_txt.map { meta, kmer_file ->
-            [meta.id, kmer_file.text.trim() as Integer]
-        })
-        .map { id, meta, reads, kmergenie_kmer ->
-            // Build k-mer list: add predicted kmer to defaults if valid
-            def default_kmers_spades = [21, 33, 55, 77]  // spades recommended defaults
-            def max_kmer_spades = 127  // spades max kmer limit
+    // KMERGENIE and GETKMERGENIEK only run if skip_kmergenie_strategy is false.
+    // The channel consequently is only populated if skip_kmergenie_strategy is false.
 
-            def default_kmers_megahit = [21, 29, 39, 59, 79, 99, 119, 141] // megahit recommended defaults
-            def max_kmer_megahit = 141 // megahit max kmer limit
+    if (!params.skip_kmergenie_strategy) {
+        KMERGENIE(ch_fastp_reads)
+        GETKMERGENIEK(KMERGENIE.out.html)
+        ch_reads_kmergenie_strategy = ch_fastp_reads
+            .map { meta, reads -> [meta.id, meta, reads] }
+            .join(GETKMERGENIEK.out.kmer_txt.map { meta, kmer_file ->
+                [meta.id, kmer_file.text.trim() as Integer]
+            })
+            .map { id, meta, reads, kmergenie_kmer ->
+                // Build k-mer list: add predicted kmer to defaults if valid
+                def default_kmers_spades = [21, 33, 55, 77]  // spades recommended defaults
+                def max_kmer_spades = 127  // spades max kmer limit
 
-            // Validate predicted kmer for spades: must be odd, in range [15, 127], and not already in list
-            def is_valid_spades = (kmergenie_kmer >= 15 &&
-                            kmergenie_kmer <= max_kmer_spades &&
-                            kmergenie_kmer % 2 == 1 &&
-                            !(kmergenie_kmer in default_kmers_spades))
+                def default_kmers_megahit = [21, 29, 39, 59, 79, 99, 119, 141] // megahit recommended defaults
+                def max_kmer_megahit = 141 // megahit max kmer limit
 
-            // Validate predicted kmer for megahit: must be odd, in range [15, 141], and not already in list
-            def is_valid_megahit = (kmergenie_kmer >= 15 &&
-                            kmergenie_kmer <= max_kmer_megahit &&
-                            kmergenie_kmer % 2 == 1 &&
-                            !(kmergenie_kmer in default_kmers_megahit))
+                // Validate predicted kmer for spades: must be odd, in range [15, 127], and not already in list
+                def is_valid_spades = (kmergenie_kmer >= 15 &&
+                                kmergenie_kmer <= max_kmer_spades &&
+                                kmergenie_kmer % 2 == 1 &&
+                                !(kmergenie_kmer in default_kmers_spades))
 
-            // Build final k-mer lists for spades
-            def kmer_list_spades = is_valid_spades ?
-                (default_kmers_spades + [kmergenie_kmer]).sort() :
-                default_kmers_spades
+                // Validate predicted kmer for megahit: must be odd, in range [15, 141], and not already in list
+                def is_valid_megahit = (kmergenie_kmer >= 15 &&
+                                kmergenie_kmer <= max_kmer_megahit &&
+                                kmergenie_kmer % 2 == 1 &&
+                                !(kmergenie_kmer in default_kmers_megahit))
 
-            // Build final k-mer lists for megahit
-            def kmer_list_megahit = is_valid_megahit ?
-                (default_kmers_megahit + [kmergenie_kmer]).sort() :
-                default_kmers_megahit
+                // Build final k-mer lists for spades
+                def kmer_list_spades = is_valid_spades ?
+                    (default_kmers_spades + [kmergenie_kmer]).sort() :
+                    default_kmers_spades
 
-            // For assemblers that only take a single k-mer, use the predicted k-mer if it's valid (between 15 and 127), or fall back to a fixed value (25)
-            def single_kmer = (kmergenie_kmer >= 15 && kmergenie_kmer <= 127 && kmergenie_kmer % 2 == 1) ? kmergenie_kmer : 25
+                // Build final k-mer lists for megahit
+                def kmer_list_megahit = is_valid_megahit ?
+                    (default_kmers_megahit + [kmergenie_kmer]).sort() :
+                    default_kmers_megahit
 
-            // Enrich metadata with k-mer strategy and lists
-            def enriched_meta = meta + [
-                kmer_strategy: 'kmergenie',
-                predicted_kmer: kmergenie_kmer,
-                kmer_list_spades: kmer_list_spades.join(','),
-                kmer_list_megahit: kmer_list_megahit.join(','),
-                single_kmer: single_kmer
-            ]
-            [enriched_meta, reads]
+                // For assemblers that only take a single k-mer, use the predicted k-mer if it's valid (between 15 and 127), or fall back to a fixed value (25)
+                def single_kmer = (kmergenie_kmer >= 15 && kmergenie_kmer <= 127 && kmergenie_kmer % 2 == 1) ? kmergenie_kmer : 25
+
+                // Enrich metadata with k-mer strategy and lists
+                def enriched_meta = meta + [
+                    kmer_strategy: 'kmergenie',
+                    predicted_kmer: kmergenie_kmer,
+                    kmer_list_spades: kmer_list_spades.join(','),
+                    kmer_list_megahit: kmer_list_megahit.join(','),
+                    single_kmer: single_kmer
+                ]
+                [enriched_meta, reads]
         }
-
+    }
 
     // Channel 3: reads_length strategy (adds kmer calculated from median reads length to default list)
-    ch_reads_reads_length_strategy = ch_fastp_reads
-        .map { meta, reads -> [meta.id, meta, reads] }
-        .join(GETSEQKITK.out.seqkitkmer_txt.map { meta, kmer_file ->
-            [meta.id, kmer_file.text.trim() as Integer]
-        })
-        .map { id, meta, reads, seqkit_kmer ->
-            // Build k-mer list: add predicted kmer to defaults if valid
-            def default_kmers_spades = [21, 33, 55, 77]  // spades recommended defaults
-            def max_kmer_spades = 127  // spades max kmer limit
+    // SEQKIT_STATS, GETSEQKITK only run if skip_reads_length_strategy is false.
+    // The channel consequently is only populated if skip_reads_length_strategy is false.
 
-            def default_kmers_megahit = [21, 29, 39, 59, 79, 99, 119, 141] // megahit recommended defaults
-            def max_kmer_megahit = 141 // megahit max kmer limit
+    if (!params.skip_reads_length_strategy) {
+        SEQKIT_STATS(ch_fastp_reads)
+        GETSEQKITK(SEQKIT_STATS.out.stats)
+        ch_reads_reads_length_strategy = ch_fastp_reads
+            .map { meta, reads -> [meta.id, meta, reads] }
+            .join(GETSEQKITK.out.seqkitkmer_txt.map { meta, kmer_file ->
+                [meta.id, kmer_file.text.trim() as Integer]
+            })
+            .map { id, meta, reads, seqkit_kmer ->
+                // Build k-mer list: add predicted kmer to defaults if valid
+                def default_kmers_spades = [21, 33, 55, 77]  // spades recommended defaults
+                def max_kmer_spades = 127  // spades max kmer limit
 
-            // Validate predicted kmer for spades: must be odd, in range [15, 127], and not already in list
-            def is_valid_spades = (seqkit_kmer >= 15 &&
-                            seqkit_kmer <= max_kmer_spades &&
-                            seqkit_kmer % 2 == 1 &&
-                            !(seqkit_kmer in default_kmers_spades))
+                def default_kmers_megahit = [21, 29, 39, 59, 79, 99, 119, 141] // megahit recommended defaults
+                def max_kmer_megahit = 141 // megahit max kmer limit
 
-            // Validate predicted kmer for megahit: must be odd, in range [15, 141], and not already in list
-            def is_valid_megahit = (seqkit_kmer >= 15 &&
-                            seqkit_kmer <= max_kmer_megahit &&
-                            seqkit_kmer % 2 == 1 &&
-                            !(seqkit_kmer in default_kmers_megahit))
+                // Validate predicted kmer for spades: must be odd, in range [15, 127], and not already in list
+                def is_valid_spades = (seqkit_kmer >= 15 &&
+                                seqkit_kmer <= max_kmer_spades &&
+                                seqkit_kmer % 2 == 1 &&
+                                !(seqkit_kmer in default_kmers_spades))
 
-            // Build final k-mer lists for spades
-            def kmer_list_spades = is_valid_spades ?
-                (default_kmers_spades + [seqkit_kmer]).sort() :
-                default_kmers_spades
+                // Validate predicted kmer for megahit: must be odd, in range [15, 141], and not already in list
+                def is_valid_megahit = (seqkit_kmer >= 15 &&
+                                seqkit_kmer <= max_kmer_megahit &&
+                                seqkit_kmer % 2 == 1 &&
+                                !(seqkit_kmer in default_kmers_megahit))
 
-            // Build final k-mer lists for megahit
-            def kmer_list_megahit = is_valid_megahit ?
-                (default_kmers_megahit + [seqkit_kmer]).sort() :
-                default_kmers_megahit
+                // Build final k-mer lists for spades
+                def kmer_list_spades = is_valid_spades ?
+                    (default_kmers_spades + [seqkit_kmer]).sort() :
+                    default_kmers_spades
 
-            // For assemblers that only take a single k-mer, use the predicted k-mer if it's valid (between 15 and 127), or fall back to a fixed value (25)
-            def single_kmer = (seqkit_kmer >= 15 && seqkit_kmer <= 127 && seqkit_kmer % 2 == 1) ? seqkit_kmer : 25
+                // Build final k-mer lists for megahit
+                def kmer_list_megahit = is_valid_megahit ?
+                    (default_kmers_megahit + [seqkit_kmer]).sort() :
+                    default_kmers_megahit
 
-            // Enrich metadata with k-mer strategy and lists
-            def enriched_meta = meta + [
-                kmer_strategy: 'reads_length',
-                predicted_kmer: seqkit_kmer,
-                kmer_list_spades: kmer_list_spades.join(','),
-                kmer_list_megahit: kmer_list_megahit.join(','),
-                single_kmer: single_kmer
-            ]
-            [enriched_meta, reads]
-        }
+                // For assemblers that only take a single k-mer, use the predicted k-mer if it's valid (between 15 and 127), or fall back to a fixed value (25)
+                def single_kmer = (seqkit_kmer >= 15 && seqkit_kmer <= 127 && seqkit_kmer % 2 == 1) ? seqkit_kmer : 25
 
+                // Enrich metadata with k-mer strategy and lists
+                def enriched_meta = meta + [
+                    kmer_strategy: 'reads_length',
+                    predicted_kmer: seqkit_kmer,
+                    kmer_list_spades: kmer_list_spades.join(','),
+                    kmer_list_megahit: kmer_list_megahit.join(','),
+                    single_kmer: single_kmer
+                ]
+                [enriched_meta, reads]
+            }
+    }
 // =================== End of k-mer strategies for genome assembly =======================
 
 
 // =================== Genome assembly with different assemblers and k-mer strategies =======================
-
-    // Spades needs a tuple with 4 elements as inputs, so we need to map the channel to add empty lists for the other 2 inputs
-    // SPADES: [ meta, illumina, pacbio, nanopore ]
-    // ch_input_reads_spades = ch_fastp_reads.map { meta, reads -> [ meta, reads, [], [] ] }
-
-    SPADES_MANUAL       ( ch_reads_manual_strategy.map { meta, reads -> [meta, reads, [], []] },
-    [],
-    []
-    )
-
-    SPADES_KMERGENIE       ( ch_reads_kmergenie_strategy.map { meta, reads -> [meta, reads, [], []] },
-    [],
-    []
-    )
-
-        SPADES_READS_LENGTH       ( ch_reads_reads_length_strategy.map { meta, reads -> [meta, reads, [], []] },
-    [],
-    []
-    )
-
-    // Megahit needs a tuple with 3 elements as input. I can't use ch_fastp_reads directly because R1 and R2 paths there are in a single list element. So I need to map the channel to split R1 and R2 into separate list elements.
-    // MEGAHIT: [ meta, reads1, reads2 ]
-    ch_input_reads_megahit_manual = ch_reads_manual_strategy.map { meta, reads -> [ meta, reads[0], reads[1] ] }
-    MEGAHIT_MANUAL      ( ch_input_reads_megahit_manual )
-
-    ch_input_reads_megahit_kmergenie = ch_reads_kmergenie_strategy.map { meta, reads -> [ meta, reads[0], reads[1] ] }
-    MEGAHIT_KMERGENIE ( ch_input_reads_megahit_kmergenie )
-
-    ch_input_reads_megahit_reads_length = ch_reads_reads_length_strategy.map { meta, reads -> [ meta, reads[0], reads[1] ] }
-    MEGAHIT_READS_LENGTH ( ch_input_reads_megahit_reads_length )
-
-    MINIA_MANUAL        ( ch_reads_manual_strategy )
-    MINIA_KMERGENIE     ( ch_reads_kmergenie_strategy )
-    MINIA_READS_LENGTH     ( ch_reads_reads_length_strategy )
-
-    ch_abyss_input_manual = ch_reads_manual_strategy.map { meta, reads -> [ meta, reads, [] ] }
-    ABYSS_MANUAL ( ch_abyss_input_manual, params.abyss_kmer )
-
-    // create an input channel with just the kmer value for abyss and sparseassembler, as they require it as input (can't be passed from the extra args)
-    ch_kmergenie_single_kmer = ch_reads_kmergenie_strategy.map { meta, reads -> meta.single_kmer }
-    ch_reads_length_single_kmer = ch_reads_reads_length_strategy.map { meta, reads -> meta.single_kmer }
-
-    ch_abyss_input_kmergenie = ch_reads_kmergenie_strategy.map { meta, reads -> [ meta, reads, [] ] }
-    ABYSS_KMERGENIE ( ch_abyss_input_kmergenie, ch_kmergenie_single_kmer )
-
-    ch_abyss_input_reads_length = ch_reads_reads_length_strategy.map { meta, reads -> [ meta, reads, [] ] }
-    ABYSS_READS_LENGTH ( ch_abyss_input_reads_length, ch_reads_length_single_kmer )
-
-    SPARSEASSEMBLER_MANUAL ( ch_reads_manual_strategy, params.sparseassembler_kmer, params.sparseassembler_genome_size, params.sparseassembler_expected_coverage )
-    SPARSEASSEMBLER_KMERGENIE ( ch_reads_kmergenie_strategy, ch_kmergenie_single_kmer, params.sparseassembler_genome_size, params.sparseassembler_expected_coverage )
-    SPARSEASSEMBLER_READS_LENGTH ( ch_reads_reads_length_strategy, ch_reads_length_single_kmer, params.sparseassembler_genome_size, params.sparseassembler_expected_coverage )
-
-// =================== End of genome assembly with different assemblers and k-mer strategies =======================
-
-
-// ==================== Redefining meta.id for downstream processes to avoid conflicts in the output names =======================
 
     // Add assembler name to meta.id for all assemblies to avoid conflicts in downstream processes that use meta.id for naming outputs (e.g. busco, quast, merquryfk)
     def createAssemblyMeta = { meta, assembly, assembler ->
@@ -222,37 +176,215 @@ workflow GENOME_ASSEMBLY {
         return [new_meta, assembly, "${meta.id}_${strategy}_${assembler}.fa"]
     }
 
-    // Create channel with new meta for downstream processes. This channel combines all assemblies from different assemblers and strategies, and maps them to the new meta with updated id.
-    def ch_draft_assemblies_input = SPADES_MANUAL.out.scaffolds
-        .mix(SPADES_KMERGENIE.out.scaffolds)
-        .mix(SPADES_READS_LENGTH.out.scaffolds)
-        .map { meta, scaffolds -> createAssemblyMeta(meta, scaffolds, 'spades') }
-        .mix( MEGAHIT_MANUAL.out.contigs.map { meta, contigs -> createAssemblyMeta(meta, contigs, 'megahit') } )
-        .mix( MEGAHIT_KMERGENIE.out.contigs.map { meta, contigs -> createAssemblyMeta(meta, contigs, 'megahit') } )
-        .mix( MEGAHIT_READS_LENGTH.out.contigs.map { meta, contigs -> createAssemblyMeta(meta, contigs, 'megahit') } )
-        .mix( MINIA_MANUAL.out.contigs.map { meta, contigs -> createAssemblyMeta(meta, contigs, 'minia') } )
-        .mix( MINIA_KMERGENIE.out.contigs.map { meta, contigs -> createAssemblyMeta(meta, contigs, 'minia') } )
-        .mix( MINIA_READS_LENGTH.out.contigs.map { meta, contigs -> createAssemblyMeta(meta, contigs, 'minia') } )
-        .mix( ABYSS_MANUAL.out.contigs.map { meta, contigs -> createAssemblyMeta(meta, contigs, 'abyss') } )
-        .mix( ABYSS_KMERGENIE.out.contigs.map { meta, contigs -> createAssemblyMeta(meta, contigs, 'abyss') } )
-        .mix( ABYSS_READS_LENGTH.out.contigs.map { meta, contigs -> createAssemblyMeta(meta, contigs, 'abyss') } )
-        .mix( SPARSEASSEMBLER_MANUAL.out.scaffolds
-            .concat(SPARSEASSEMBLER_MANUAL.out.contigs)
-            .unique { meta, assembly -> meta.id }
-            .map { meta, assembly -> createAssemblyMeta(meta, assembly, 'sparseassembler') }
-        )
-        .mix( SPARSEASSEMBLER_KMERGENIE.out.scaffolds
-            .concat(SPARSEASSEMBLER_KMERGENIE.out.contigs)
-            .unique { meta, assembly -> meta.id }
-            .map { meta, assembly -> createAssemblyMeta(meta, assembly, 'sparseassembler') }
-        )
-        .mix( SPARSEASSEMBLER_READS_LENGTH.out.scaffolds
-            .concat(SPARSEASSEMBLER_READS_LENGTH.out.contigs)
-            .unique { meta, assembly -> meta.id }
-            .map { meta, assembly -> createAssemblyMeta(meta, assembly, 'sparseassembler') }
-        )
+    // Create channel with new meta for downstream processes (after assembly). This channel combines all assemblies from different assemblers and strategies, and maps them to the new meta with updated id.
+    def ch_draft_assemblies_input = Channel.empty()
 
-// ==================== End of redefining meta.id for downstream processes to avoid conflicts in the output names =======================
+    // ======= Spades assemblies - nested conditionals (assembler × strategy) ======
+    // Spades is only run if skip_spades is false. Within that, each strategy is only run if its corresponding skip parameter is false.
+    // The channel with Spades assemblies is populated accordingly and mixed into the common ch_draft_assemblies_input channel.
+    // Spades needs a tuple with 4 elements as inputs, so we need to map the channel to add empty lists for the other 2 inputs (see PREPROCESSING subworkflow for example)
+    // SPADES: [ meta, illumina, pacbio, nanopore ]
+
+    if (!params.skip_spades) {
+
+        if (!params.skip_manual_strategy) {
+            SPADES_MANUAL(
+                ch_reads_manual_strategy.map { meta, reads -> [meta, reads, [], []] },
+                [],
+                []
+            )
+            ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
+                SPADES_MANUAL.out.scaffolds
+                    .map { meta, scaffolds -> createAssemblyMeta(meta, scaffolds, 'spades') }
+            )
+        }
+
+        if (!params.skip_kmergenie_strategy) {
+            SPADES_KMERGENIE(
+                ch_reads_kmergenie_strategy.map { meta, reads -> [meta, reads, [], []] },
+                [],
+                []
+            )
+            ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
+                SPADES_KMERGENIE.out.scaffolds
+                    .map { meta, scaffolds -> createAssemblyMeta(meta, scaffolds, 'spades') }
+            )
+        }
+
+        if (!params.skip_reads_length_strategy) {
+            SPADES_READS_LENGTH(
+                ch_reads_reads_length_strategy.map { meta, reads -> [meta, reads, [], []] },
+                [],
+                []
+            )
+            ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
+                SPADES_READS_LENGTH.out.scaffolds
+                    .map { meta, scaffolds -> createAssemblyMeta(meta, scaffolds, 'spades') }
+            )
+        }
+    }
+
+    // ======= Megahit assemblies - nested conditionals (assembler × strategy) ======
+    // Megahit is only run if skip_megahit is false. Within that, each strategy is only run if its corresponding skip parameter is false.
+    // The channel with Megahit assemblies is populated accordingly and mixed into the common ch_draft_assemblies_input channel.
+    // Megahit needs a tuple with 3 elements as input. I can't use ch_fastp_reads directly because R1 and R2 paths there are in a single list element. So I need to map the channel to split R1 and R2 into separate list elements.
+    // MEGAHIT: [ meta, reads1, reads2 ]
+
+    if (!params.skip_megahit) {
+
+        if (!params.skip_manual_strategy) {
+            ch_megahit_input_manual = ch_reads_manual_strategy.map { meta, reads -> [meta, reads[0], reads[1]] }
+            MEGAHIT_MANUAL(ch_megahit_input_manual)
+
+            ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
+                MEGAHIT_MANUAL.out.contigs.map { meta, contigs -> createAssemblyMeta(meta, contigs, 'megahit') }
+            )
+        }
+
+        if (!params.skip_kmergenie_strategy) {
+            ch_megahit_input_kmergenie = ch_reads_kmergenie_strategy.map { meta, reads -> [ meta, reads[0], reads[1] ] }
+            MEGAHIT_KMERGENIE(ch_megahit_input_kmergenie)
+
+            ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
+                MEGAHIT_KMERGENIE.out.contigs.map { meta, contigs -> createAssemblyMeta(meta, contigs, 'megahit') }
+            )
+        }
+
+        if (!params.skip_reads_length_strategy) {
+            ch_megahit_input_reads_length = ch_reads_reads_length_strategy.map { meta, reads -> [ meta, reads[0], reads[1] ] }
+            MEGAHIT_READS_LENGTH(ch_megahit_input_reads_length)
+
+            ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
+                MEGAHIT_READS_LENGTH.out.contigs.map { meta, contigs -> createAssemblyMeta(meta, contigs, 'megahit') }
+            )
+        }
+    }
+
+    // ======= MINIA assemblies - nested conditionals (assembler × strategy) ======
+    // Minia is only run if skip_minia is false. Within that, each strategy is only run if its corresponding skip parameter is false.
+    // The channel with Minia assemblies is populated accordingly and mixed into the common ch_draft_assemblies_input channel.
+    if (!params.skip_minia) {
+
+        if (!params.skip_manual_strategy) {
+            MINIA_MANUAL(ch_reads_manual_strategy)
+
+            ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
+                MINIA_MANUAL.out.contigs.map { meta, contigs -> createAssemblyMeta(meta, contigs, 'minia') }
+            )
+        }
+
+        if (!params.skip_kmergenie_strategy) {
+            MINIA_KMERGENIE(ch_reads_kmergenie_strategy)
+
+            ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
+                MINIA_KMERGENIE.out.contigs.map { meta, contigs -> createAssemblyMeta(meta, contigs, 'minia') }
+            )
+        }
+
+        if (!params.skip_reads_length_strategy) {
+            MINIA_READS_LENGTH(ch_reads_reads_length_strategy)
+
+            ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
+                MINIA_READS_LENGTH.out.contigs.map { meta, contigs -> createAssemblyMeta(meta, contigs, 'minia') }
+            )
+        }
+    }
+
+    // ======= ABYSS assemblies - nested conditionals (assembler × strategy) ======
+    // ABYSS is only run if skip_abyss is false. Within that, each strategy is only run if its corresponding skip parameter is false.
+    // The channel with ABYSS assemblies is populated accordingly and mixed into the common ch_draft_assemblies_input channel.
+    if (!params.skip_abyss) {
+
+        if (!params.skip_manual_strategy) {
+            ch_abyss_input_manual = ch_reads_manual_strategy.map { meta, reads -> [ meta, reads, [] ] }
+            ABYSS_MANUAL(ch_abyss_input_manual, params.abyss_kmer)
+
+            ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
+                ABYSS_MANUAL.out.scaffolds.map { meta, scaffolds -> createAssemblyMeta(meta, scaffolds, 'abyss') }
+            )
+        }
+
+        if (!params.skip_kmergenie_strategy) {
+            // Create k-mer channel for ABYSS (needs single kmer value)
+            ch_abyss_kmergenie_single_kmer = ch_reads_kmergenie_strategy.map { meta, reads -> meta.single_kmer }
+            ch_abyss_input_kmergenie = ch_reads_kmergenie_strategy.map { meta, reads -> [ meta, reads, [] ] }
+            ABYSS_KMERGENIE(ch_abyss_input_kmergenie, ch_abyss_kmergenie_single_kmer)
+
+            ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
+                ABYSS_KMERGENIE.out.scaffolds.map { meta, scaffolds -> createAssemblyMeta(meta, scaffolds, 'abyss') }
+            )
+        }
+
+        if (!params.skip_reads_length_strategy) {
+            // Create k-mer channel for ABYSS (needs single kmer value)
+            ch_abyss_reads_length_single_kmer = ch_reads_reads_length_strategy.map { meta, reads -> meta.single_kmer }
+            ch_abyss_input_reads_length = ch_reads_reads_length_strategy.map { meta, reads -> [ meta, reads, [] ] }
+            ABYSS_READS_LENGTH(ch_abyss_input_reads_length, ch_abyss_reads_length_single_kmer)
+
+            ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
+                ABYSS_READS_LENGTH.out.scaffolds.map { meta, scaffolds -> createAssemblyMeta(meta, scaffolds, 'abyss') }
+            )
+        }
+    }
+
+    // ======= SPARSEASSEMBLER assemblies - nested conditionals (assembler × strategy) ======
+    // SPARSEASSEMBLER is only run if skip_sparseassembler is false. Within that, each strategy is only run if its corresponding skip parameter is false.
+    // The channel with SPARSEASSEMBLER assemblies is populated accordingly and mixed into the common ch_draft_assemblies_input channel.
+    // SPARSEASSEMBLER is a special case because it can output contigs or scaffolds depending on the parameters used and quality of the reads
+    if (!params.skip_sparseassembler) {
+
+        if (!params.skip_manual_strategy) {
+            SPARSEASSEMBLER_MANUAL(
+                ch_reads_manual_strategy,
+                params.sparseassembler_kmer,
+                params.sparseassembler_genome_size,
+                params.sparseassembler_expected_coverage
+            )
+
+            ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
+                SPARSEASSEMBLER_MANUAL.out.scaffolds
+                    .concat(SPARSEASSEMBLER_MANUAL.out.contigs)
+                    .unique { meta, assembly -> meta.id }
+                    .map { meta, assembly -> createAssemblyMeta(meta, assembly, 'sparseassembler') }
+            )
+        }
+
+        if (!params.skip_kmergenie_strategy) {
+            // Create k-mer channel for SPARSEASSEMBLER (needs single kmer value)
+            ch_sparseassembler_kmergenie_single_kmer = ch_reads_kmergenie_strategy.map { meta, reads -> meta.single_kmer }
+            SPARSEASSEMBLER_KMERGENIE(
+                ch_reads_kmergenie_strategy,
+                ch_sparseassembler_kmergenie_single_kmer,
+                params.sparseassembler_genome_size,
+                params.sparseassembler_expected_coverage
+            )
+
+            ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
+                SPARSEASSEMBLER_KMERGENIE.out.scaffolds
+                    .concat(SPARSEASSEMBLER_KMERGENIE.out.contigs)
+                    .unique { meta, assembly -> meta.id }
+                    .map { meta, assembly -> createAssemblyMeta(meta, assembly, 'sparseassembler') }
+            )
+        }
+
+        if (!params.skip_reads_length_strategy) {
+            // Create k-mer channel for SPARSEASSEMBLER (needs single kmer value)
+            ch_sparseassembler_reads_length_single_kmer = ch_reads_reads_length_strategy.map { meta, reads -> meta.single_kmer }
+            SPARSEASSEMBLER_READS_LENGTH(
+                ch_reads_reads_length_strategy,
+                ch_sparseassembler_reads_length_single_kmer,
+                params.sparseassembler_genome_size,
+                params.sparseassembler_expected_coverage
+            )
+
+            ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
+                SPARSEASSEMBLER_READS_LENGTH.out.scaffolds
+                    .concat(SPARSEASSEMBLER_READS_LENGTH.out.contigs)
+                    .unique { meta, assembly -> meta.id }
+                    .map { meta, assembly -> createAssemblyMeta(meta, assembly, 'sparseassembler') }
+            )
+        }
+    }
 
 
 // =================== Draft assemblies QC =======================
@@ -331,30 +463,30 @@ workflow GENOME_ASSEMBLY {
     QUAST ( ch_quast_input,[[],[]], [[],[]] ) // no reference fasta or gff for quast
 
     emit:
-    seqkit_stats                                = SEQKIT_STATS.out.stats           // channel: [ val(meta), [ bam ] ]
-    getseqkitk_kmer                             = GETSEQKITK.out.seqkitkmer_txt              // channel: [ val(meta), path('*.txt') ]
-    kmergenie_html                              = KMERGENIE.out.html             // channel: [ val(meta), path('*.html') ]
-    getkmergeniek_k                             = GETKMERGENIEK.out.kmer_txt              // channel: [ val(meta), path('*.k') ]
+    seqkit_stats                                = params.skip_reads_length_strategy ? Channel.empty() : SEQKIT_STATS.out.stats           // channel: [ val(meta), [ bam ] ]
+    getseqkitk_kmer                             = params.skip_reads_length_strategy ? Channel.empty() : GETSEQKITK.out.seqkitkmer_txt              // channel: [ val(meta), path('*.txt') ]
+    kmergenie_html                              = params.skip_kmergenie_strategy ? Channel.empty() : KMERGENIE.out.html             // channel: [ val(meta), path('*.html') ]
+    getkmergeniek_k                             = params.skip_kmergenie_strategy ? Channel.empty() : GETKMERGENIEK.out.kmer_txt              // channel: [ val(meta), path('*.k') ]
     fastk_ktab                                  = FASTK_FASTK.out.ktab             // channel: [ val(meta), path('*.ktab') ]
     fastk_hist                                  = FASTK_FASTK.out.hist             // channel: [ val(meta), path('*.hist') ]
-    spades_scaffolds_manual                     = SPADES_MANUAL.out.scaffolds             // channel: [ val(meta), path('*.scaffolds.fa.gz') ]
-    spades_scaffolds_kmergenie                  = SPADES_KMERGENIE.out.scaffolds          // channel: [ val(meta), path('*.scaffolds.fa.gz') ]
-    spades_scaffolds_reads_length               = SPADES_READS_LENGTH.out.scaffolds     // channel: [ val(meta), path('*.scaffolds.fa.gz') ]
-    megahit_contigs_manual                      = MEGAHIT_MANUAL.out.contigs              // channel: [ val(meta), path('*.contigs.fa.gz') ]
-    megahit_contigs_kmergenie                   = MEGAHIT_KMERGENIE.out.contigs           // channel: [ val(meta), path('*.contigs.fa.gz') ]
-    megahit_contigs_reads_length                = MEGAHIT_READS_LENGTH.out.contigs        // channel: [ val(meta), path('*.contigs.fa.gz') ]
-    minia_contigs_manual                        = MINIA_MANUAL.out.contigs                // channel: [ val(meta), path('*.contigs.fa') ]
-    minia_contigs_kmergenie                     = MINIA_KMERGENIE.out.contigs                // channel: [ val(meta), path('*.contigs.fa') ]
-    minia_contigs_reads_length                  = MINIA_READS_LENGTH.out.contigs                // channel: [ val(meta), path('*.contigs.fa') ]
-    abyss_scaffolds_manual                      = ABYSS_MANUAL.out.scaffolds      // channel: [ val(meta), path('*.scaffolds.fa.gz') ]
-    abyss_scaffolds_kmergenie                   = ABYSS_KMERGENIE.out.scaffolds   // channel: [ val(meta), path('*.scaffolds.fa.gz') ]
-    abyss_scaffolds_reads_length                = ABYSS_READS_LENGTH.out.scaffolds   // channel: [ val(meta), path('*.scaffolds.fa.gz') ]
-    sparseassembler_scaffolds_manual            = SPARSEASSEMBLER_MANUAL.out.scaffolds    // channel: [ val(meta), path('*.scaffolds.fa.gz') ]
-    sparseassembler_contigs_manual              = SPARSEASSEMBLER_MANUAL.out.contigs      // channel: [ val(meta), path('*.contigs.fa.gz') ]
-    sparseassembler_scaffolds_kmergenie         = SPARSEASSEMBLER_KMERGENIE.out.scaffolds // channel: [ val(meta), path('*.scaffolds.fa.gz') ]
-    sparseassembler_contigs_kmergenie           = SPARSEASSEMBLER_KMERGENIE.out.contigs   // channel: [ val(meta), path('*.contigs.fa.gz') ]
-    sparseassembler_scaffolds_reads_length      = SPARSEASSEMBLER_READS_LENGTH.out.scaffolds // channel: [ val(meta), path('*.scaffolds.fa.gz') ]
-    sparseassembler_contigs_reads_length        = SPARSEASSEMBLER_READS_LENGTH.out.contigs   // channel: [ val(meta), path('*.contigs.fa.gz') ]
+    spades_scaffolds_manual                     = (params.skip_spades || params.skip_manual_strategy) ? Channel.empty() : SPADES_MANUAL.out.scaffolds
+    spades_scaffolds_kmergenie                  = (params.skip_spades || params.skip_kmergenie_strategy) ? Channel.empty() : SPADES_KMERGENIE.out.scaffolds
+    spades_scaffolds_reads_length               = (params.skip_spades || params.skip_reads_length_strategy) ? Channel.empty() : SPADES_READS_LENGTH.out.scaffolds
+    megahit_contigs_manual                      = (params.skip_megahit || params.skip_manual_strategy) ? Channel.empty() : MEGAHIT_MANUAL.out.contigs
+    megahit_contigs_kmergenie                   = (params.skip_megahit || params.skip_kmergenie_strategy) ? Channel.empty() : MEGAHIT_KMERGENIE.out.contigs
+    megahit_contigs_reads_length                = (params.skip_megahit || params.skip_reads_length_strategy) ? Channel.empty() : MEGAHIT_READS_LENGTH.out.contigs
+    minia_contigs_manual                        = (params.skip_minia || params.skip_manual_strategy) ? Channel.empty() : MINIA_MANUAL.out.contigs
+    minia_contigs_kmergenie                     = (params.skip_minia || params.skip_kmergenie_strategy) ? Channel.empty() : MINIA_KMERGENIE.out.contigs
+    minia_contigs_reads_length                  = (params.skip_minia || params.skip_reads_length_strategy) ? Channel.empty() : MINIA_READS_LENGTH.out.contigs
+    abyss_scaffolds_manual                      = (params.skip_abyss || params.skip_manual_strategy) ? Channel.empty() : ABYSS_MANUAL.out.scaffolds
+    abyss_scaffolds_kmergenie                   = (params.skip_abyss || params.skip_kmergenie_strategy) ? Channel.empty() : ABYSS_KMERGENIE.out.scaffolds
+    abyss_scaffolds_reads_length                = (params.skip_abyss || params.skip_reads_length_strategy) ? Channel.empty() : ABYSS_READS_LENGTH.out.scaffolds
+    sparseassembler_scaffolds_manual            = (params.skip_sparseassembler || params.skip_manual_strategy) ? Channel.empty() : SPARSEASSEMBLER_MANUAL.out.scaffolds
+    sparseassembler_contigs_manual              = (params.skip_sparseassembler || params.skip_manual_strategy) ? Channel.empty() : SPARSEASSEMBLER_MANUAL.out.contigs
+    sparseassembler_scaffolds_kmergenie         = (params.skip_sparseassembler || params.skip_kmergenie_strategy) ? Channel.empty() : SPARSEASSEMBLER_KMERGENIE.out.scaffolds
+    sparseassembler_contigs_kmergenie           = (params.skip_sparseassembler || params.skip_kmergenie_strategy) ? Channel.empty() : SPARSEASSEMBLER_KMERGENIE.out.contigs
+    sparseassembler_scaffolds_reads_length      = (params.skip_sparseassembler || params.skip_reads_length_strategy) ? Channel.empty() : SPARSEASSEMBLER_READS_LENGTH.out.scaffolds
+    sparseassembler_contigs_reads_length        = (params.skip_sparseassembler || params.skip_reads_length_strategy) ? Channel.empty() : SPARSEASSEMBLER_READS_LENGTH.out.contigs
     renamed_assemblies                          = RENAME_ASSEMBLIES.out.renamed_assemblies // channel: [ val(meta), path('*.fa.gz') ]
     busco_batch_summary                         = BUSCO_BUSCO.out.batch_summary  // channel: [ val(meta), path('*.busco.batch_summary.txt') ]
     busco_short_summaries_txt                   = BUSCO_BUSCO.out.short_summaries_txt  // channel: [ val(meta), path('short_summary.*.txt') ]

--- a/subworkflows/local/genome_assembly/main.nf
+++ b/subworkflows/local/genome_assembly/main.nf
@@ -1,29 +1,29 @@
-include { SEQKIT_STATS                         } from '../../../modules/nf-core/seqkit/stats/main'
-include { GETSEQKITK                            } from '../../../modules/local/getseqkitk/main'
+include { SEQKIT_STATS                                     } from '../../../modules/nf-core/seqkit/stats/main'
+include { GETSEQKITK                                       } from '../../../modules/local/getseqkitk/main'
 // include { SEQKIT_STATS as SEQKIT_STATS_MERGED  } from '../../../modules/nf-core/seqkit/stats/main' I can't work on this if the preprocessing subworkflow is not updated to ouput merged reads.
-include { KMERGENIE                            } from '../../../modules/nf-core/kmergenie/main'
-include { GETKMERGENIEK                        } from '../../../modules/local/getkmergeniek/main'
-include { FASTK_FASTK                          } from '../../../modules/nf-core/fastk/fastk/main'
-include { SPADES as SPADES_MANUAL              } from '../../../modules/nf-core/spades/main'
-include { SPADES as SPADES_KMERGENIE           } from '../../../modules/nf-core/spades/main'
-include { SPADES as SPADES_READS_LENGTH         } from '../../../modules/nf-core/spades/main'
-include { MEGAHIT as MEGAHIT_MANUAL            } from '../../../modules/nf-core/megahit/main'
-include { MEGAHIT as MEGAHIT_KMERGENIE         } from '../../../modules/nf-core/megahit/main'
-include { MEGAHIT as MEGAHIT_READS_LENGTH         } from '../../../modules/nf-core/megahit/main'
-include { MINIA as MINIA_MANUAL                } from '../../../modules/nf-core/minia/main'
-include { MINIA as MINIA_KMERGENIE             } from '../../../modules/nf-core/minia/main'
-include { MINIA as MINIA_READS_LENGTH             } from '../../../modules/nf-core/minia/main'
-include { ABYSS_ABYSSPE as ABYSS_MANUAL } from '../../../modules/nf-core/abyss/abysspe/main'
-include { ABYSS_ABYSSPE as ABYSS_KMERGENIE } from '../../../modules/nf-core/abyss/abysspe/main'
-include { ABYSS_ABYSSPE as ABYSS_READS_LENGTH } from '../../../modules/nf-core/abyss/abysspe/main'
-include { SPARSEASSEMBLER as SPARSEASSEMBLER_MANUAL } from '../../../modules/local/sparseassembler/main'
-include { SPARSEASSEMBLER as SPARSEASSEMBLER_KMERGENIE } from '../../../modules/local/sparseassembler/main'
-include { SPARSEASSEMBLER as SPARSEASSEMBLER_READS_LENGTH } from '../../../modules/local/sparseassembler/main'
-include { RENAME_ASSEMBLIES                    } from '../../../modules/local/rename_assemblies/main'
-include { BUSCO_BUSCO                          } from '../../../modules/nf-core/busco/busco/main'
-include { BUSCO_BUSCO as BUSCO_SPECIFIC        } from '../../../modules/nf-core/busco/busco/main'
-include { MERQURYFK_MERQURYFK                  } from '../../../modules/nf-core/merquryfk/merquryfk/main'
-include { QUAST                                } from '../../../modules/nf-core/quast/main'
+include { KMERGENIE                                        } from '../../../modules/nf-core/kmergenie/main'
+include { GETKMERGENIEK                                    } from '../../../modules/local/getkmergeniek/main'
+include { FASTK_FASTK                                      } from '../../../modules/nf-core/fastk/fastk/main'
+include { SPADES as SPADES_MANUAL                          } from '../../../modules/nf-core/spades/main'
+include { SPADES as SPADES_KMERGENIE                       } from '../../../modules/nf-core/spades/main'
+include { SPADES as SPADES_READS_LENGTH                    } from '../../../modules/nf-core/spades/main'
+include { MEGAHIT as MEGAHIT_MANUAL                        } from '../../../modules/nf-core/megahit/main'
+include { MEGAHIT as MEGAHIT_KMERGENIE                     } from '../../../modules/nf-core/megahit/main'
+include { MEGAHIT as MEGAHIT_READS_LENGTH                  } from '../../../modules/nf-core/megahit/main'
+include { MINIA as MINIA_MANUAL                            } from '../../../modules/nf-core/minia/main'
+include { MINIA as MINIA_KMERGENIE                         } from '../../../modules/nf-core/minia/main'
+include { MINIA as MINIA_READS_LENGTH                      } from '../../../modules/nf-core/minia/main'
+include { ABYSS_ABYSSPE as ABYSS_MANUAL                    } from '../../../modules/nf-core/abyss/abysspe/main'
+include { ABYSS_ABYSSPE as ABYSS_KMERGENIE                 } from '../../../modules/nf-core/abyss/abysspe/main'
+include { ABYSS_ABYSSPE as ABYSS_READS_LENGTH              } from '../../../modules/nf-core/abyss/abysspe/main'
+include { SPARSEASSEMBLER as SPARSEASSEMBLER_MANUAL        } from '../../../modules/local/sparseassembler/main'
+include { SPARSEASSEMBLER as SPARSEASSEMBLER_KMERGENIE     } from '../../../modules/local/sparseassembler/main'
+include { SPARSEASSEMBLER as SPARSEASSEMBLER_READS_LENGTH  } from '../../../modules/local/sparseassembler/main'
+include { RENAME_ASSEMBLIES                                } from '../../../modules/local/rename_assemblies/main'
+include { BUSCO_BUSCO                                      } from '../../../modules/nf-core/busco/busco/main'
+include { BUSCO_BUSCO as BUSCO_SPECIFIC                    } from '../../../modules/nf-core/busco/busco/main'
+include { MERQURYFK_MERQURYFK                              } from '../../../modules/nf-core/merquryfk/merquryfk/main'
+include { QUAST                                            } from '../../../modules/nf-core/quast/main'
 
 workflow GENOME_ASSEMBLY {
 
@@ -51,9 +51,18 @@ workflow GENOME_ASSEMBLY {
     // KMERGENIE and GETKMERGENIEK only run if skip_kmergenie_strategy is false.
     // The channel consequently is only populated if skip_kmergenie_strategy is false.
 
+    // Initialise channels for outputs as empty to avoid use of conditionals in emit section.
+    def ch_kmergenie_html = channel.empty()
+    def ch_getkmergeniek_k = channel.empty()
+
     if (!params.skip_kmergenie_strategy) {
         KMERGENIE(ch_fastp_reads)
         GETKMERGENIEK(KMERGENIE.out.html)
+
+        // Capture output for emits (avoids using conditionals in emits section)
+        ch_kmergenie_html = KMERGENIE.out.html
+        ch_getkmergeniek_k = GETKMERGENIEK.out.kmer_txt
+
         ch_reads_kmergenie_strategy = ch_fastp_reads
             .map { meta, reads -> [meta.id, meta, reads] }
             .join(GETKMERGENIEK.out.kmer_txt.map { meta, kmer_file ->
@@ -108,9 +117,19 @@ workflow GENOME_ASSEMBLY {
     // SEQKIT_STATS, GETSEQKITK only run if skip_reads_length_strategy is false.
     // The channel consequently is only populated if skip_reads_length_strategy is false.
 
+
+    // Initialise channels for outputs as empty to avoid use of conditionals in emit section.
+    def ch_seqkit_stats = channel.empty()
+    def ch_getseqkitk_kmer = channel.empty()
+
     if (!params.skip_reads_length_strategy) {
         SEQKIT_STATS(ch_fastp_reads)
         GETSEQKITK(SEQKIT_STATS.out.stats)
+
+        // Capture output for emits (avoids using conditionals in emits section)
+        ch_seqkit_stats = SEQKIT_STATS.out.stats
+        ch_getseqkitk_kmer = GETSEQKITK.out.seqkitkmer_txt
+
         ch_reads_reads_length_strategy = ch_fastp_reads
             .map { meta, reads -> [meta.id, meta, reads] }
             .join(GETSEQKITK.out.seqkitkmer_txt.map { meta, kmer_file ->
@@ -185,6 +204,12 @@ workflow GENOME_ASSEMBLY {
     // Spades needs a tuple with 4 elements as inputs, so we need to map the channel to add empty lists for the other 2 inputs (see PREPROCESSING subworkflow for example)
     // SPADES: [ meta, illumina, pacbio, nanopore ]
 
+
+    // Initialise channels for outputs as empty to avoid use of conditionals in emit section.
+    def ch_spades_scaffolds_manual = channel.empty()
+    def ch_spades_scaffolds_kmergenie = channel.empty()
+    def ch_spades_scaffolds_reads_length = channel.empty()
+
     if (!params.skip_spades) {
 
         if (!params.skip_manual_strategy) {
@@ -193,6 +218,9 @@ workflow GENOME_ASSEMBLY {
                 [],
                 []
             )
+            // Capture output for emits (avoids using conditionals in emits section)
+            ch_spades_scaffolds_manual = SPADES_MANUAL.out.scaffolds
+            // Mix into draft assemblies channel with new meta
             ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
                 SPADES_MANUAL.out.scaffolds
                     .map { meta, scaffolds -> createAssemblyMeta(meta, scaffolds, 'spades') }
@@ -205,6 +233,11 @@ workflow GENOME_ASSEMBLY {
                 [],
                 []
             )
+
+            // Capture output for emits (avoids using conditionals in emits section)
+            ch_spades_scaffolds_kmergenie = SPADES_KMERGENIE.out.scaffolds
+
+            // Mix into draft assemblies channel with new meta
             ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
                 SPADES_KMERGENIE.out.scaffolds
                     .map { meta, scaffolds -> createAssemblyMeta(meta, scaffolds, 'spades') }
@@ -217,6 +250,11 @@ workflow GENOME_ASSEMBLY {
                 [],
                 []
             )
+
+            // Capture output for emits (avoids using conditionals in emits section)
+            ch_spades_scaffolds_reads_length = SPADES_READS_LENGTH.out.scaffolds
+
+            // Mix into draft assemblies channel with new meta
             ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
                 SPADES_READS_LENGTH.out.scaffolds
                     .map { meta, scaffolds -> createAssemblyMeta(meta, scaffolds, 'spades') }
@@ -230,12 +268,22 @@ workflow GENOME_ASSEMBLY {
     // Megahit needs a tuple with 3 elements as input. I can't use ch_fastp_reads directly because R1 and R2 paths there are in a single list element. So I need to map the channel to split R1 and R2 into separate list elements.
     // MEGAHIT: [ meta, reads1, reads2 ]
 
+
+    // Initialise channels for outputs as empty to avoid use of conditionals in emit section.
+    def ch_megahit_contigs_manual = channel.empty()
+    def ch_megahit_contigs_kmergenie = channel.empty()
+    def ch_megahit_contigs_reads_length = channel.empty()
+
     if (!params.skip_megahit) {
 
         if (!params.skip_manual_strategy) {
             ch_megahit_input_manual = ch_reads_manual_strategy.map { meta, reads -> [meta, reads[0], reads[1]] }
             MEGAHIT_MANUAL(ch_megahit_input_manual)
 
+            // Capture output for emits (avoids using conditionals in emits section)
+            ch_megahit_contigs_manual = MEGAHIT_MANUAL.out.contigs
+
+            // Mix into draft assemblies channel with new meta
             ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
                 MEGAHIT_MANUAL.out.contigs.map { meta, contigs -> createAssemblyMeta(meta, contigs, 'megahit') }
             )
@@ -245,6 +293,10 @@ workflow GENOME_ASSEMBLY {
             ch_megahit_input_kmergenie = ch_reads_kmergenie_strategy.map { meta, reads -> [ meta, reads[0], reads[1] ] }
             MEGAHIT_KMERGENIE(ch_megahit_input_kmergenie)
 
+            // Capture output for emits (avoids using conditionals in emits section)
+            ch_megahit_contigs_kmergenie = MEGAHIT_KMERGENIE.out.contigs
+
+            // Mix into draft assemblies channel with new meta
             ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
                 MEGAHIT_KMERGENIE.out.contigs.map { meta, contigs -> createAssemblyMeta(meta, contigs, 'megahit') }
             )
@@ -254,6 +306,10 @@ workflow GENOME_ASSEMBLY {
             ch_megahit_input_reads_length = ch_reads_reads_length_strategy.map { meta, reads -> [ meta, reads[0], reads[1] ] }
             MEGAHIT_READS_LENGTH(ch_megahit_input_reads_length)
 
+            // Capture output for emits (avoids using conditionals in emits section)
+            ch_megahit_contigs_reads_length = MEGAHIT_READS_LENGTH.out.contigs
+
+            // Mix into draft assemblies channel with new meta
             ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
                 MEGAHIT_READS_LENGTH.out.contigs.map { meta, contigs -> createAssemblyMeta(meta, contigs, 'megahit') }
             )
@@ -263,11 +319,21 @@ workflow GENOME_ASSEMBLY {
     // ======= MINIA assemblies - nested conditionals (assembler × strategy) ======
     // Minia is only run if skip_minia is false. Within that, each strategy is only run if its corresponding skip parameter is false.
     // The channel with Minia assemblies is populated accordingly and mixed into the common ch_draft_assemblies_input channel.
+
+    // Initialise channels for outputs as empty to avoid use of conditionals in emit section.
+    def ch_minia_contigs_manual = channel.empty()
+    def ch_minia_contigs_kmergenie = channel.empty()
+    def ch_minia_contigs_reads_length = channel.empty()
+
     if (!params.skip_minia) {
 
         if (!params.skip_manual_strategy) {
             MINIA_MANUAL(ch_reads_manual_strategy)
 
+            // Capture output for emits (avoids using conditionals in emits section)
+            ch_minia_contigs_manual = MINIA_MANUAL.out.contigs
+
+            // Mix into draft assemblies channel with new meta
             ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
                 MINIA_MANUAL.out.contigs.map { meta, contigs -> createAssemblyMeta(meta, contigs, 'minia') }
             )
@@ -276,6 +342,10 @@ workflow GENOME_ASSEMBLY {
         if (!params.skip_kmergenie_strategy) {
             MINIA_KMERGENIE(ch_reads_kmergenie_strategy)
 
+            // Capture output for emits (avoids using conditionals in emits section)
+            ch_minia_contigs_kmergenie = MINIA_KMERGENIE.out.contigs
+
+            // Mix into draft assemblies channel with new meta
             ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
                 MINIA_KMERGENIE.out.contigs.map { meta, contigs -> createAssemblyMeta(meta, contigs, 'minia') }
             )
@@ -284,6 +354,10 @@ workflow GENOME_ASSEMBLY {
         if (!params.skip_reads_length_strategy) {
             MINIA_READS_LENGTH(ch_reads_reads_length_strategy)
 
+            // Capture output for emits (avoids using conditionals in emits section)
+            ch_minia_contigs_reads_length = MINIA_READS_LENGTH.out.contigs
+
+            // Mix into draft assemblies channel with new meta
             ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
                 MINIA_READS_LENGTH.out.contigs.map { meta, contigs -> createAssemblyMeta(meta, contigs, 'minia') }
             )
@@ -293,12 +367,22 @@ workflow GENOME_ASSEMBLY {
     // ======= ABYSS assemblies - nested conditionals (assembler × strategy) ======
     // ABYSS is only run if skip_abyss is false. Within that, each strategy is only run if its corresponding skip parameter is false.
     // The channel with ABYSS assemblies is populated accordingly and mixed into the common ch_draft_assemblies_input channel.
+
+    // Initialise channels for outputs as empty to avoid use of conditionals in emit section.
+    def ch_abyss_scaffolds_manual = channel.empty()
+    def ch_abyss_scaffolds_kmergenie = channel.empty()
+    def ch_abyss_scaffolds_reads_length = channel.empty()
+
     if (!params.skip_abyss) {
 
         if (!params.skip_manual_strategy) {
             ch_abyss_input_manual = ch_reads_manual_strategy.map { meta, reads -> [ meta, reads, [] ] }
             ABYSS_MANUAL(ch_abyss_input_manual, params.abyss_kmer)
 
+            // Capture output for emits (avoids using conditionals in emits section)
+            ch_abyss_scaffolds_manual = ABYSS_MANUAL.out.scaffolds
+
+            // Mix into draft assemblies channel with new meta
             ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
                 ABYSS_MANUAL.out.scaffolds.map { meta, scaffolds -> createAssemblyMeta(meta, scaffolds, 'abyss') }
             )
@@ -310,6 +394,10 @@ workflow GENOME_ASSEMBLY {
             ch_abyss_input_kmergenie = ch_reads_kmergenie_strategy.map { meta, reads -> [ meta, reads, [] ] }
             ABYSS_KMERGENIE(ch_abyss_input_kmergenie, ch_abyss_kmergenie_single_kmer)
 
+            // Capture output for emits (avoids using conditionals in emits section)
+            ch_abyss_scaffolds_kmergenie = ABYSS_KMERGENIE.out.scaffolds
+
+            // Mix into draft assemblies channel with new meta
             ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
                 ABYSS_KMERGENIE.out.scaffolds.map { meta, scaffolds -> createAssemblyMeta(meta, scaffolds, 'abyss') }
             )
@@ -321,6 +409,10 @@ workflow GENOME_ASSEMBLY {
             ch_abyss_input_reads_length = ch_reads_reads_length_strategy.map { meta, reads -> [ meta, reads, [] ] }
             ABYSS_READS_LENGTH(ch_abyss_input_reads_length, ch_abyss_reads_length_single_kmer)
 
+            // Capture output for emits (avoids using conditionals in emits section)
+            ch_abyss_scaffolds_reads_length = ABYSS_READS_LENGTH.out.scaffolds
+
+            // Mix into draft assemblies channel with new meta
             ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
                 ABYSS_READS_LENGTH.out.scaffolds.map { meta, scaffolds -> createAssemblyMeta(meta, scaffolds, 'abyss') }
             )
@@ -331,6 +423,15 @@ workflow GENOME_ASSEMBLY {
     // SPARSEASSEMBLER is only run if skip_sparseassembler is false. Within that, each strategy is only run if its corresponding skip parameter is false.
     // The channel with SPARSEASSEMBLER assemblies is populated accordingly and mixed into the common ch_draft_assemblies_input channel.
     // SPARSEASSEMBLER is a special case because it can output contigs or scaffolds depending on the parameters used and quality of the reads
+
+    // Initialise channels for outputs as empty to avoid use of conditionals in emit section.
+    def ch_sparseassembler_scaffolds_manual = channel.empty()
+    def ch_sparseassembler_contigs_manual = channel.empty()
+    def ch_sparseassembler_scaffolds_kmergenie = channel.empty()
+    def ch_sparseassembler_contigs_kmergenie = channel.empty()
+    def ch_sparseassembler_scaffolds_reads_length = channel.empty()
+    def ch_sparseassembler_contigs_reads_length = channel.empty()
+
     if (!params.skip_sparseassembler) {
 
         if (!params.skip_manual_strategy) {
@@ -341,6 +442,11 @@ workflow GENOME_ASSEMBLY {
                 params.sparseassembler_expected_coverage
             )
 
+            // Capture output for emits (avoids using conditionals in emits section)
+            ch_sparseassembler_scaffolds_manual = SPARSEASSEMBLER_MANUAL.out.scaffolds
+            ch_sparseassembler_contigs_manual = SPARSEASSEMBLER_MANUAL.out.contigs
+
+            // Mix into draft assemblies channel with new meta
             ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
                 SPARSEASSEMBLER_MANUAL.out.scaffolds
                     .concat(SPARSEASSEMBLER_MANUAL.out.contigs)
@@ -359,6 +465,11 @@ workflow GENOME_ASSEMBLY {
                 params.sparseassembler_expected_coverage
             )
 
+            // Capture output for emits (avoids using conditionals in emits section)
+            ch_sparseassembler_scaffolds_kmergenie = SPARSEASSEMBLER_KMERGENIE.out.scaffolds
+            ch_sparseassembler_contigs_kmergenie = SPARSEASSEMBLER_KMERGENIE.out.contigs
+
+            // Mix into draft assemblies channel with new meta
             ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
                 SPARSEASSEMBLER_KMERGENIE.out.scaffolds
                     .concat(SPARSEASSEMBLER_KMERGENIE.out.contigs)
@@ -377,6 +488,11 @@ workflow GENOME_ASSEMBLY {
                 params.sparseassembler_expected_coverage
             )
 
+            // Capture output for emits (avoids using conditionals in emits section)
+            ch_sparseassembler_scaffolds_reads_length = SPARSEASSEMBLER_READS_LENGTH.out.scaffolds
+            ch_sparseassembler_contigs_reads_length = SPARSEASSEMBLER_READS_LENGTH.out.contigs
+
+            // Mix into draft assemblies channel with new meta
             ch_draft_assemblies_input = ch_draft_assemblies_input.mix(
                 SPARSEASSEMBLER_READS_LENGTH.out.scaffolds
                     .concat(SPARSEASSEMBLER_READS_LENGTH.out.contigs)
@@ -463,37 +579,52 @@ workflow GENOME_ASSEMBLY {
     QUAST ( ch_quast_input,[[],[]], [[],[]] ) // no reference fasta or gff for quast
 
     emit:
-    seqkit_stats                                = params.skip_reads_length_strategy ? Channel.empty() : SEQKIT_STATS.out.stats           // channel: [ val(meta), [ bam ] ]
-    getseqkitk_kmer                             = params.skip_reads_length_strategy ? Channel.empty() : GETSEQKITK.out.seqkitkmer_txt              // channel: [ val(meta), path('*.txt') ]
-    kmergenie_html                              = params.skip_kmergenie_strategy ? Channel.empty() : KMERGENIE.out.html             // channel: [ val(meta), path('*.html') ]
-    getkmergeniek_k                             = params.skip_kmergenie_strategy ? Channel.empty() : GETKMERGENIEK.out.kmer_txt              // channel: [ val(meta), path('*.k') ]
-    fastk_ktab                                  = FASTK_FASTK.out.ktab             // channel: [ val(meta), path('*.ktab') ]
-    fastk_hist                                  = FASTK_FASTK.out.hist             // channel: [ val(meta), path('*.hist') ]
-    spades_scaffolds_manual                     = (params.skip_spades || params.skip_manual_strategy) ? Channel.empty() : SPADES_MANUAL.out.scaffolds
-    spades_scaffolds_kmergenie                  = (params.skip_spades || params.skip_kmergenie_strategy) ? Channel.empty() : SPADES_KMERGENIE.out.scaffolds
-    spades_scaffolds_reads_length               = (params.skip_spades || params.skip_reads_length_strategy) ? Channel.empty() : SPADES_READS_LENGTH.out.scaffolds
-    megahit_contigs_manual                      = (params.skip_megahit || params.skip_manual_strategy) ? Channel.empty() : MEGAHIT_MANUAL.out.contigs
-    megahit_contigs_kmergenie                   = (params.skip_megahit || params.skip_kmergenie_strategy) ? Channel.empty() : MEGAHIT_KMERGENIE.out.contigs
-    megahit_contigs_reads_length                = (params.skip_megahit || params.skip_reads_length_strategy) ? Channel.empty() : MEGAHIT_READS_LENGTH.out.contigs
-    minia_contigs_manual                        = (params.skip_minia || params.skip_manual_strategy) ? Channel.empty() : MINIA_MANUAL.out.contigs
-    minia_contigs_kmergenie                     = (params.skip_minia || params.skip_kmergenie_strategy) ? Channel.empty() : MINIA_KMERGENIE.out.contigs
-    minia_contigs_reads_length                  = (params.skip_minia || params.skip_reads_length_strategy) ? Channel.empty() : MINIA_READS_LENGTH.out.contigs
-    abyss_scaffolds_manual                      = (params.skip_abyss || params.skip_manual_strategy) ? Channel.empty() : ABYSS_MANUAL.out.scaffolds
-    abyss_scaffolds_kmergenie                   = (params.skip_abyss || params.skip_kmergenie_strategy) ? Channel.empty() : ABYSS_KMERGENIE.out.scaffolds
-    abyss_scaffolds_reads_length                = (params.skip_abyss || params.skip_reads_length_strategy) ? Channel.empty() : ABYSS_READS_LENGTH.out.scaffolds
-    sparseassembler_scaffolds_manual            = (params.skip_sparseassembler || params.skip_manual_strategy) ? Channel.empty() : SPARSEASSEMBLER_MANUAL.out.scaffolds
-    sparseassembler_contigs_manual              = (params.skip_sparseassembler || params.skip_manual_strategy) ? Channel.empty() : SPARSEASSEMBLER_MANUAL.out.contigs
-    sparseassembler_scaffolds_kmergenie         = (params.skip_sparseassembler || params.skip_kmergenie_strategy) ? Channel.empty() : SPARSEASSEMBLER_KMERGENIE.out.scaffolds
-    sparseassembler_contigs_kmergenie           = (params.skip_sparseassembler || params.skip_kmergenie_strategy) ? Channel.empty() : SPARSEASSEMBLER_KMERGENIE.out.contigs
-    sparseassembler_scaffolds_reads_length      = (params.skip_sparseassembler || params.skip_reads_length_strategy) ? Channel.empty() : SPARSEASSEMBLER_READS_LENGTH.out.scaffolds
-    sparseassembler_contigs_reads_length        = (params.skip_sparseassembler || params.skip_reads_length_strategy) ? Channel.empty() : SPARSEASSEMBLER_READS_LENGTH.out.contigs
-    renamed_assemblies                          = RENAME_ASSEMBLIES.out.renamed_assemblies // channel: [ val(meta), path('*.fa.gz') ]
-    busco_batch_summary                         = BUSCO_BUSCO.out.batch_summary  // channel: [ val(meta), path('*.busco.batch_summary.txt') ]
-    busco_short_summaries_txt                   = BUSCO_BUSCO.out.short_summaries_txt  // channel: [ val(meta), path('short_summary.*.txt') ]
-    busco_full_table                            = BUSCO_BUSCO.out.full_table  // channel: [ val(meta), path('full_table.*.txt') ]
-    busco_batch_summary_specific                = BUSCO_SPECIFIC.out.batch_summary  // channel: [ val(meta), path('*.busco.batch_summary.txt') ]
-    busco_short_summaries_txt_specific          = BUSCO_SPECIFIC.out.short_summaries_txt  // channel: [ val(meta), path('short_summary.*.txt') ]
-    busco_full_table_specific                   = BUSCO_SPECIFIC.out.full_table  // channel: [ val(meta), path('full_table.*.txt') ]
-    merquryfk_completeness_stats                = MERQURYFK_MERQURYFK.out.stats // channel: [ val(meta), path('*.completeness.stats') ]
-    quast_results                               = QUAST.out.results         // channel: [ val(meta), path("${prefix}") ]
+    // Fastk outputs (unconditional processes, it's needed as input for merquryfk)
+    fastk_ktab                                  = FASTK_FASTK.out.ktab
+    fastk_hist                                  = FASTK_FASTK.out.hist
+
+    // K-mer strategy outputs
+    seqkit_stats                                = ch_seqkit_stats
+    getseqkitk_kmer                             = ch_getseqkitk_kmer
+    kmergenie_html                              = ch_kmergenie_html
+    getkmergeniek_k                             = ch_getkmergeniek_kmer
+
+    // SPAdes outputs
+    spades_scaffolds_manual                     = ch_spades_scaffolds_manual
+    spades_scaffolds_kmergenie                  = ch_spades_scaffolds_kmergenie
+    spades_scaffolds_reads_length               = ch_spades_scaffolds_reads_length
+
+    // MEGAHIT outputs
+    megahit_contigs_manual                      = ch_megahit_contigs_manual
+    megahit_contigs_kmergenie                   = ch_megahit_contigs_kmergenie
+    megahit_contigs_reads_length                = ch_megahit_contigs_reads_length
+
+    // Minia outputs
+    minia_contigs_manual                        = ch_minia_contigs_manual
+    minia_contigs_kmergenie                     = ch_minia_contigs_kmergenie
+    minia_contigs_reads_length                  = ch_minia_contigs_reads_length
+
+    // ABySS outputs
+    abyss_scaffolds_manual                      = ch_abyss_scaffolds_manual
+    abyss_scaffolds_kmergenie                   = ch_abyss_scaffolds_kmergenie
+    abyss_scaffolds_reads_length                = ch_abyss_scaffolds_reads_length
+
+    // SparseAssembler outputs
+    sparseassembler_scaffolds_manual            = ch_sparseassembler_scaffolds_manual
+    sparseassembler_contigs_manual              = ch_sparseassembler_contigs_manual
+    sparseassembler_scaffolds_kmergenie         = ch_sparseassembler_scaffolds_kmergenie
+    sparseassembler_contigs_kmergenie           = ch_sparseassembler_contigs_kmergenie
+    sparseassembler_scaffolds_reads_length      = ch_sparseassembler_scaffolds_reads_length
+    sparseassembler_contigs_reads_length        = ch_sparseassembler_contigs_reads_length
+
+    // Downstream outputs (unconditional processes)
+    renamed_assemblies                          = RENAME_ASSEMBLIES.out.renamed_assemblies
+    busco_batch_summary                         = BUSCO_BUSCO.out.batch_summary
+    busco_short_summaries_txt                   = BUSCO_BUSCO.out.short_summaries_txt
+    busco_full_table                            = BUSCO_BUSCO.out.full_table
+    busco_batch_summary_specific                = BUSCO_SPECIFIC.out.batch_summary
+    busco_short_summaries_txt_specific          = BUSCO_SPECIFIC.out.short_summaries_txt
+    busco_full_table_specific                   = BUSCO_SPECIFIC.out.full_table
+    merquryfk_completeness_stats                = MERQURYFK_MERQURYFK.out.stats
+    quast_results                               = QUAST.out.results
 }

--- a/subworkflows/local/genome_assembly/main.nf
+++ b/subworkflows/local/genome_assembly/main.nf
@@ -32,7 +32,13 @@ workflow GENOME_ASSEMBLY {
 
     main:
 
-    FASTK_FASTK  ( ch_fastp_reads )
+    // Add reads_type to the meta (as we will have another subworkflow handling merged reads)
+    ch_paired_reads = ch_fastp_reads.map { meta, reads ->
+        def new_meta = meta + [ reads_type: 'R1R2' ]
+        tuple(new_meta, reads)
+    }
+
+    FASTK_FASTK  ( ch_paired_reads )
 
 // ==================== K-mer strategies for genome assembly =======================
 
@@ -42,7 +48,7 @@ workflow GENOME_ASSEMBLY {
 
     // Channel 1: Manual strategy (uses config values)
     if (!params.skip_manual_strategy) {
-        ch_reads_manual_strategy = ch_fastp_reads
+        ch_reads_manual_strategy = ch_paired_reads
             .map { meta, reads ->
                 [meta + [kmer_strategy: 'manual'], reads]
             }
@@ -56,14 +62,14 @@ workflow GENOME_ASSEMBLY {
     def ch_getkmergeniek_k = channel.empty()
 
     if (!params.skip_kmergenie_strategy) {
-        KMERGENIE(ch_fastp_reads)
+        KMERGENIE(ch_paired_reads)
         GETKMERGENIEK(KMERGENIE.out.html)
 
         // Capture output for emits (avoids using conditionals in emits section)
         ch_kmergenie_html = KMERGENIE.out.html
         ch_getkmergeniek_k = GETKMERGENIEK.out.kmer_txt
 
-        ch_reads_kmergenie_strategy = ch_fastp_reads
+        ch_reads_kmergenie_strategy = ch_paired_reads
             .map { meta, reads -> [meta.id, meta, reads] }
             .join(GETKMERGENIEK.out.kmer_txt.map { meta, kmer_file ->
                 [meta.id, kmer_file.text.trim() as Integer]
@@ -123,14 +129,14 @@ workflow GENOME_ASSEMBLY {
     def ch_getseqkitk_kmer = channel.empty()
 
     if (!params.skip_reads_length_strategy) {
-        SEQKIT_STATS(ch_fastp_reads)
+        SEQKIT_STATS(ch_paired_reads)
         GETSEQKITK(SEQKIT_STATS.out.stats)
 
         // Capture output for emits (avoids using conditionals in emits section)
         ch_seqkit_stats = SEQKIT_STATS.out.stats
         ch_getseqkitk_kmer = GETSEQKITK.out.seqkitkmer_txt
 
-        ch_reads_reads_length_strategy = ch_fastp_reads
+        ch_reads_reads_length_strategy = ch_paired_reads
             .map { meta, reads -> [meta.id, meta, reads] }
             .join(GETSEQKITK.out.seqkitkmer_txt.map { meta, kmer_file ->
                 [meta.id, kmer_file.text.trim() as Integer]
@@ -187,12 +193,13 @@ workflow GENOME_ASSEMBLY {
     // Add assembler name to meta.id for all assemblies to avoid conflicts in downstream processes that use meta.id for naming outputs (e.g. busco, quast, merquryfk)
     def createAssemblyMeta = { meta, assembly, assembler ->
         def strategy = meta.kmer_strategy
+        def reads_type = meta.reads_type
         def new_meta = meta + [
-            assembly_id: "${meta.id}_${assembler}_${strategy}",
+            assembly_id: "${meta.id}_${reads_type}_${assembler}_${strategy}",
             assembler: assembler,
             id: meta.id
         ]
-        return [new_meta, assembly, "${meta.id}_${strategy}_${assembler}.fa"]
+        return [new_meta, assembly, "${meta.id}_${reads_type}_${strategy}_${assembler}.fa"]
     }
 
     // Create channel with new meta for downstream processes (after assembly). This channel combines all assemblies from different assemblers and strategies, and maps them to the new meta with updated id.
@@ -265,7 +272,7 @@ workflow GENOME_ASSEMBLY {
     // ======= Megahit assemblies - nested conditionals (assembler × strategy) ======
     // Megahit is only run if skip_megahit is false. Within that, each strategy is only run if its corresponding skip parameter is false.
     // The channel with Megahit assemblies is populated accordingly and mixed into the common ch_draft_assemblies_input channel.
-    // Megahit needs a tuple with 3 elements as input. I can't use ch_fastp_reads directly because R1 and R2 paths there are in a single list element. So I need to map the channel to split R1 and R2 into separate list elements.
+    // Megahit needs a tuple with 3 elements as input. I can't use ch_paired_reads directly because R1 and R2 paths there are in a single list element. So I need to map the channel to split R1 and R2 into separate list elements.
     // MEGAHIT: [ meta, reads1, reads2 ]
 
 

--- a/subworkflows/local/genome_assembly/main.nf
+++ b/subworkflows/local/genome_assembly/main.nf
@@ -42,9 +42,9 @@ workflow GENOME_ASSEMBLY {
 
 // ==================== K-mer strategies for genome assembly =======================
 
-    def ch_reads_manual_strategy = Channel.empty()
-    def ch_reads_kmergenie_strategy = Channel.empty()
-    def ch_reads_reads_length_strategy = Channel.empty()
+    def ch_reads_manual_strategy = channel.empty()
+    def ch_reads_kmergenie_strategy = channel.empty()
+    def ch_reads_reads_length_strategy = channel.empty()
 
     // Channel 1: Manual strategy (uses config values)
     if (!params.skip_manual_strategy) {

--- a/subworkflows/local/genome_assembly/main.nf
+++ b/subworkflows/local/genome_assembly/main.nf
@@ -594,7 +594,7 @@ workflow GENOME_ASSEMBLY {
     seqkit_stats                                = ch_seqkit_stats
     getseqkitk_kmer                             = ch_getseqkitk_kmer
     kmergenie_html                              = ch_kmergenie_html
-    getkmergeniek_k                             = ch_getkmergeniek_kmer
+    getkmergeniek_k                             = ch_getkmergeniek_k
 
     // SPAdes outputs
     spades_scaffolds_manual                     = ch_spades_scaffolds_manual


### PR DESCRIPTION
This PR introduces the conditional logic that allows to skip specific kmer strategies or assemblers from `nextflow.config`.

It closes #47 #48

It also contains a modules update due to a bulk update in nf-core.

Parameters to optionally switch off kmer strategies:
```
    // k-mer strategy options
    skip_manual_strategy       = false // whether to skip manual k-mer strategy selection and use the default k-mer strategy
    skip_kmergenie_strategy     = false // whether to skip Kmergenie strategy selection and use the default k-mer strategy
    skip_reads_length_strategy   = false // whether to skip read length strategy selection and use the default k-mer strategy
```

Each assembler has a `skip_assembler` parameter:
```
    skip_spades                  = false // whether to skip SPAdes assembly
    skip_megahit               = false // whether to skip MEGAHIT assembly
```
etc.

The genome_assembly/main.nf has been re-structured to reflect the introduction of the conditional logic. 

I tested all the possible combinations:
```
nextflow run . -profile test,docker --outdir results --input assets/samplesheet_assembly.csv -process.errorStrategy=ignore # '-process.errorStrategy=ignore' used to allow the pipeline to finish ignoring sparseassemblers errors

executor >  local (147)
[-        ] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FALCO_RAW                                             -
[-        ] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FASTP_TRIM                                            -
[-        ] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FASTP_MERGE                                           -
[-        ] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FALCO_AFTER_FASTP                                     -
[-        ] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FALCO_AFTER_MERGE                                     -
[-        ] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FALCO_QCSTAT_COMPILING                                -
[-        ] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FQSTAT                                                -
[-        ] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FQSTAT_SUMMARY                                        -
[-        ] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FASTK_FASTK                                           -
[-        ] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FASTK_HISTEX                                          -
[-        ] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:GENESCOPEFK_P1                                        -
[-        ] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:GENESCOPEFK_P2                                        -
[-        ] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:KMER_STAT_SUMMARY                                     -
[6d/05be86] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:FASTK_FASTK (sim_Com_5_10k_cov60)                   [100%] 2 of 2 ✔
[25/f48fa0] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:KMERGENIE (sim_Com_5_10k_cov60)                     [100%] 2 of 2 ✔
[0a/a9c300] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:GETKMERGENIEK (sim_Com_5_10k_cov60)                 [100%] 2 of 2 ✔
[1d/d320e5] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:SEQKIT_STATS (sim_Com_5_100k_cov40)                 [100%] 2 of 2 ✔
[5f/bb1182] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:GETSEQKITK (sim_Com_5_100k_cov40)                   [100%] 2 of 2 ✔
[6a/5847da] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:SPADES_MANUAL (sim_Com_5_10k_cov60)                 [100%] 2 of 2 ✔
[c7/3e2079] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:SPADES_KMERGENIE (sim_Com_5_10k_cov60)              [100%] 2 of 2 ✔
[3d/14bd8c] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:SPADES_READS_LENGTH (sim_Com_5_100k_cov40)          [100%] 2 of 2 ✔
[aa/e36f9a] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MEGAHIT_MANUAL (sim_Com_5_100k_cov40)               [100%] 2 of 2 ✔
[d4/e1862a] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MEGAHIT_KMERGENIE (sim_Com_5_10k_cov60)             [100%] 2 of 2 ✔
[68/8f23a3] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MEGAHIT_READS_LENGTH (sim_Com_5_100k_cov40)         [100%] 2 of 2 ✔
[d6/30bc64] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MINIA_MANUAL (sim_Com_5_10k_cov60)                  [100%] 2 of 2 ✔
[76/37957a] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MINIA_KMERGENIE (sim_Com_5_10k_cov60)               [100%] 2 of 2 ✔
[b8/376494] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MINIA_READS_LENGTH (sim_Com_5_100k_cov40)           [100%] 2 of 2 ✔
[72/20e697] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:ABYSS_MANUAL (sim_Com_5_10k_cov60)                  [100%] 2 of 2 ✔
[1b/139116] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:ABYSS_KMERGENIE (sim_Com_5_10k_cov60)               [100%] 2 of 2 ✔
[0b/2ba56c] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:ABYSS_READS_LENGTH (sim_Com_5_100k_cov40)           [100%] 2 of 2 ✔
[67/818ee0] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:SPARSEASSEMBLER_MANUAL (sim_Com_5_100k_cov40)       [100%] 2 of 2 ✔
[a0/9cd532] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:SPARSEASSEMBLER_KMERGENIE (sim_Com_5_10k_cov60)     [100%] 2 of 2, ignored: 2 ✔
[bc/18a80d] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:SPARSEASSEMBLER_READS_LENGTH (sim_Com_5_100k_cov40) [100%] 2 of 2, ignored: 2 ✔
[e8/06cee8] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:RENAME_ASSEMBLIES (sim_Com_5_100k_cov40)            [100%] 26 of 26 ✔
[fd/5f4b81] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:BUSCO_BUSCO (sim_Com_5_100k_cov40)                  [100%] 26 of 26 ✔
[d5/e857a1] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:BUSCO_SPECIFIC (sim_Com_5_100k_cov40)               [100%] 26 of 26 ✔
[a3/b8ab39] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MERQURYFK_MERQURYFK (sim_Com_5_100k_cov40)          [100%] 26 of 26 ✔
[15/1871f4] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:QUAST (sim_Com_5_10k_cov60)                         [100%] 2 of 2 ✔
[-        ] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:CONTAMINATION_DETECTION:TIARA_TIARA                                 -
[-        ] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:CONTAMINATION_DETECTION:FCSGX_RUNGX                                 -
[-        ] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:CONTAMINATION_DETECTION:CONVERTFCSRPT                               -
[-        ] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:CONTAMINATION_DETECTION:COMPARISON                                  -
[2d/7b25b7] process > NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:MULTIQC (multiqc_report)                                            [100%] 1 of 1 ✔
-[nf-core/fspassemblypipeline] Pipeline completed successfully, but with errored process(es) -
Completed at: 24-Apr-2026 11:32:33
Duration    : 32m 10s
CPU hours   : 1.9 (5.4% failed)
Succeeded   : 143
Ignored     : 4
Failed      : 4
```

```
nextflow run . -profile test,docker --outdir results --input assets/samplesheet_assembly.csv -process.errorStrategy=ignore -resume --skip_spades # '-process.errorStrategy=ignore' used to allow the pipeline to finish ignoring sparseassemblers errors

executor >  local (7)
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FALCO_RAW                                             -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FASTP_TRIM                                            -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FASTP_MERGE                                           -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FALCO_AFTER_FASTP                                     -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FALCO_AFTER_MERGE                                     -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FALCO_QCSTAT_COMPILING                                -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FQSTAT                                                -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FQSTAT_SUMMARY                                        -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FASTK_FASTK                                           -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FASTK_HISTEX                                          -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:GENESCOPEFK_P1                                        -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:GENESCOPEFK_P2                                        -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:KMER_STAT_SUMMARY                                     -
[14/df7f91] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:FASTK_FASTK (sim_Com_5_100k_cov40)                  [100%] 2 of 2, cached: 2 ✔
[25/f48fa0] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:KMERGENIE (sim_Com_5_10k_cov60)                     [100%] 2 of 2, cached: 2 ✔
[16/17a5be] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:GETKMERGENIEK (sim_Com_5_100k_cov40)                [100%] 2 of 2, cached: 2 ✔
[1d/d320e5] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:SEQKIT_STATS (sim_Com_5_100k_cov40)                 [100%] 2 of 2, cached: 2 ✔
[5f/bb1182] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:GETSEQKITK (sim_Com_5_100k_cov40)                   [100%] 2 of 2, cached: 2 ✔
[39/41d5d8] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MEGAHIT_MANUAL (sim_Com_5_10k_cov60)                [100%] 2 of 2, cached: 2 ✔
[d4/e1862a] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MEGAHIT_KMERGENIE (sim_Com_5_10k_cov60)             [100%] 2 of 2, cached: 2 ✔
[68/8f23a3] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MEGAHIT_READS_LENGTH (sim_Com_5_100k_cov40)         [100%] 2 of 2, cached: 2 ✔
[41/941b21] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MINIA_MANUAL (sim_Com_5_100k_cov40)                 [100%] 2 of 2, cached: 2 ✔
[76/37957a] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MINIA_KMERGENIE (sim_Com_5_10k_cov60)               [100%] 2 of 2, cached: 2 ✔
[b8/376494] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MINIA_READS_LENGTH (sim_Com_5_100k_cov40)           [100%] 2 of 2, cached: 2 ✔
[79/9d25d8] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:ABYSS_MANUAL (sim_Com_5_100k_cov40)                 [100%] 2 of 2, cached: 2 ✔
[1b/139116] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:ABYSS_KMERGENIE (sim_Com_5_10k_cov60)               [100%] 2 of 2, cached: 2 ✔
[0b/2ba56c] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:ABYSS_READS_LENGTH (sim_Com_5_100k_cov40)           [100%] 2 of 2, cached: 2 ✔
[67/818ee0] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:SPARSEASSEMBLER_MANUAL (sim_Com_5_100k_cov40)       [100%] 2 of 2, cached: 2 ✔
[52/5b6a30] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:SPARSEASSEMBLER_KMERGENIE (sim_Com_5_100k_cov40)    [100%] 2 of 2, ignored: 2 ✔
[2e/53d787] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:SPARSEASSEMBLER_READS_LENGTH (sim_Com_5_100k_cov40) [100%] 2 of 2, ignored: 2 ✔
[49/31eeeb] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:RENAME_ASSEMBLIES (sim_Com_5_100k_cov40)            [100%] 20 of 20, cached: 20 ✔
[05/dcdeac] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:BUSCO_BUSCO (sim_Com_5_10k_cov60)                   [100%] 20 of 20, cached: 20 ✔
[dc/812a19] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:BUSCO_SPECIFIC (sim_Com_5_100k_cov40)               [100%] 20 of 20, cached: 20 ✔
[20/2b2d7a] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MERQURYFK_MERQURYFK (sim_Com_5_100k_cov40)          [100%] 20 of 20, cached: 20 ✔
[71/ddceff] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:QUAST (sim_Com_5_100k_cov40)                        [100%] 2 of 2 ✔
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:CONTAMINATION_DETECTION:TIARA_TIARA                                 -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:CONTAMINATION_DETECTION:FCSGX_RUNGX                                 -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:CONTAMINATION_DETECTION:CONVERTFCSRPT                               -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:CONTAMINATION_DETECTION:COMPARISON                                  -
[2e/2aae40] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:MULTIQC (multiqc_report)                                            [100%] 1 of 1 ✔
-[nf-core/fspassemblypipeline] Pipeline completed successfully, but with errored process(es) -
[6a/e4329d] NOTE: Process `NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:SPARSEASSEMBLER_READS_LENGTH (sim_Com_5_10k_cov60)` terminated with an error exit status (136) -- Error is ignored
[2e/53d787] NOTE: Process `NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:SPARSEASSEMBLER_READS_LENGTH (sim_Com_5_100k_cov40)` terminated with an error exit status (136) -- Error is ignored
Completed at: 24-Apr-2026 11:49:46
Duration    : 3m 35s
CPU hours   : 1.5 (92.2% cached, 7.1% failed)
Succeeded   : 3
Cached      : 110
Ignored     : 4
Failed      : 4
```

```
nextflow run . -profile test,docker --outdir results --input assets/samplesheet_assembly.csv -resume --skip_spades --skip_sparseassembler

executor >  local (1)
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FALCO_RAW                                     -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FASTP_TRIM                                    -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FASTP_MERGE                                   -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FALCO_AFTER_FASTP                             -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FALCO_AFTER_MERGE                             -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FALCO_QCSTAT_COMPILING                        -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FQSTAT                                        -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FQSTAT_SUMMARY                                -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FASTK_FASTK                                   -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FASTK_HISTEX                                  -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:GENESCOPEFK_P1                                -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:GENESCOPEFK_P2                                -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:KMER_STAT_SUMMARY                             -
[14/df7f91] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:FASTK_FASTK (sim_Com_5_100k_cov40)          [100%] 2 of 2, cached: 2 ✔
[da/d50b04] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:KMERGENIE (sim_Com_5_100k_cov40)            [100%] 2 of 2, cached: 2 ✔
[0a/a9c300] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:GETKMERGENIEK (sim_Com_5_10k_cov60)         [100%] 2 of 2, cached: 2 ✔
[1d/d320e5] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:SEQKIT_STATS (sim_Com_5_100k_cov40)         [100%] 2 of 2, cached: 2 ✔
[5f/bb1182] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:GETSEQKITK (sim_Com_5_100k_cov40)           [100%] 2 of 2, cached: 2 ✔
[39/41d5d8] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MEGAHIT_MANUAL (sim_Com_5_10k_cov60)        [100%] 2 of 2, cached: 2 ✔
[d4/e1862a] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MEGAHIT_KMERGENIE (sim_Com_5_10k_cov60)     [100%] 2 of 2, cached: 2 ✔
[68/8f23a3] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MEGAHIT_READS_LENGTH (sim_Com_5_100k_cov40) [100%] 2 of 2, cached: 2 ✔
[d6/30bc64] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MINIA_MANUAL (sim_Com_5_10k_cov60)          [100%] 2 of 2, cached: 2 ✔
[0e/41a9f1] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MINIA_KMERGENIE (sim_Com_5_100k_cov40)      [100%] 2 of 2, cached: 2 ✔
[b8/376494] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MINIA_READS_LENGTH (sim_Com_5_100k_cov40)   [100%] 2 of 2, cached: 2 ✔
[72/20e697] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:ABYSS_MANUAL (sim_Com_5_10k_cov60)          [100%] 2 of 2, cached: 2 ✔
[1b/139116] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:ABYSS_KMERGENIE (sim_Com_5_10k_cov60)       [100%] 2 of 2, cached: 2 ✔
[0b/2ba56c] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:ABYSS_READS_LENGTH (sim_Com_5_100k_cov40)   [100%] 2 of 2, cached: 2 ✔
[fe/4a64b7] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:RENAME_ASSEMBLIES (sim_Com_5_100k_cov40)    [100%] 18 of 18, cached: 18 ✔
[77/d1ed4f] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:BUSCO_BUSCO (sim_Com_5_100k_cov40)          [100%] 18 of 18, cached: 18 ✔
[f6/c469bf] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:BUSCO_SPECIFIC (sim_Com_5_100k_cov40)       [100%] 18 of 18, cached: 18 ✔
[a9/c8bc5a] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MERQURYFK_MERQURYFK (sim_Com_5_100k_cov40)  [100%] 18 of 18, cached: 18 ✔
[e4/5a0de5] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:QUAST (sim_Com_5_100k_cov40)                [100%] 2 of 2, cached: 2 ✔
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:CONTAMINATION_DETECTION:TIARA_TIARA                         -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:CONTAMINATION_DETECTION:FCSGX_RUNGX                         -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:CONTAMINATION_DETECTION:CONVERTFCSRPT                       -
[7d/594a50] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:MULTIQC (multiqc_report)                                    [100%] 1 of 1 ✔
Plus 1 more processes waiting for tasks…
-[nf-core/fspassemblypipeline] Pipeline completed successfully-
```

```
nextflow run . -profile test,docker --outdir results --input assets/samplesheet_assembly.csv -resume --skip_spades --skip_sparseassembler --skip_abyss

executor >  local (1)
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FALCO_RAW                                     -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FASTP_TRIM                                    -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FASTP_MERGE                                   -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FALCO_AFTER_FASTP                             -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FALCO_AFTER_MERGE                             -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FALCO_QCSTAT_COMPILING                        -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FQSTAT                                        -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FQSTAT_SUMMARY                                -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FASTK_FASTK                                   -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FASTK_HISTEX                                  -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:GENESCOPEFK_P1                                -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:GENESCOPEFK_P2                                -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:KMER_STAT_SUMMARY                             -
[14/df7f91] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:FASTK_FASTK (sim_Com_5_100k_cov40)          [100%] 2 of 2, cached: 2 ✔
[da/d50b04] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:KMERGENIE (sim_Com_5_100k_cov40)            [100%] 2 of 2, cached: 2 ✔
[16/17a5be] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:GETKMERGENIEK (sim_Com_5_100k_cov40)        [100%] 2 of 2, cached: 2 ✔
[60/d3c374] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:SEQKIT_STATS (sim_Com_5_10k_cov60)          [100%] 2 of 2, cached: 2 ✔
[5f/bb1182] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:GETSEQKITK (sim_Com_5_100k_cov40)           [100%] 2 of 2, cached: 2 ✔
[aa/e36f9a] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MEGAHIT_MANUAL (sim_Com_5_100k_cov40)       [100%] 2 of 2, cached: 2 ✔
[13/6f61e9] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MEGAHIT_KMERGENIE (sim_Com_5_100k_cov40)    [100%] 2 of 2, cached: 2 ✔
[68/8f23a3] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MEGAHIT_READS_LENGTH (sim_Com_5_100k_cov40) [100%] 2 of 2, cached: 2 ✔
[41/941b21] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MINIA_MANUAL (sim_Com_5_100k_cov40)         [100%] 2 of 2, cached: 2 ✔
[0e/41a9f1] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MINIA_KMERGENIE (sim_Com_5_100k_cov40)      [100%] 2 of 2, cached: 2 ✔
[f2/b87a06] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MINIA_READS_LENGTH (sim_Com_5_10k_cov60)    [100%] 2 of 2, cached: 2 ✔
[98/9501c9] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:RENAME_ASSEMBLIES (sim_Com_5_100k_cov40)    [100%] 12 of 12, cached: 12 ✔
[6f/ae7dac] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:BUSCO_BUSCO (sim_Com_5_10k_cov60)           [100%] 12 of 12, cached: 12 ✔
[e9/c5f9a3] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:BUSCO_SPECIFIC (sim_Com_5_100k_cov40)       [100%] 12 of 12, cached: 12 ✔
[a9/c8bc5a] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MERQURYFK_MERQURYFK (sim_Com_5_100k_cov40)  [100%] 12 of 12, cached: 12 ✔
[ba/2d3967] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:QUAST (sim_Com_5_100k_cov40)                [100%] 2 of 2, cached: 2 ✔
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:CONTAMINATION_DETECTION:TIARA_TIARA                         -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:CONTAMINATION_DETECTION:FCSGX_RUNGX                         -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:CONTAMINATION_DETECTION:CONVERTFCSRPT                       -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:CONTAMINATION_DETECTION:COMPARISON                          -
[60/608eee] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:MULTIQC (multiqc_report)                                    [100%] 1 of 1 ✔
-[nf-core/fspassemblypipeline] Pipeline completed successfully-

```

```
nextflow run . -profile test,docker --outdir results --input assets/samplesheet_assembly.csv -resume --skip_spades --skip_sparseassembler --skip_abyss --skip_minia

executor >  local (3)
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FALCO_RAW                                     -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FASTP_TRIM                                    -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FASTP_MERGE                                   -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FALCO_AFTER_FASTP                             -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FALCO_AFTER_MERGE                             -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FALCO_QCSTAT_COMPILING                        -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FQSTAT                                        -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FQSTAT_SUMMARY                                -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FASTK_FASTK                                   -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FASTK_HISTEX                                  -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:GENESCOPEFK_P1                                -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:GENESCOPEFK_P2                                -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:KMER_STAT_SUMMARY                             -
[6d/05be86] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:FASTK_FASTK (sim_Com_5_10k_cov60)           [100%] 2 of 2, cached: 2 ✔
[25/f48fa0] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:KMERGENIE (sim_Com_5_10k_cov60)             [100%] 2 of 2, cached: 2 ✔
[0a/a9c300] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:GETKMERGENIEK (sim_Com_5_10k_cov60)         [100%] 2 of 2, cached: 2 ✔
[1d/d320e5] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:SEQKIT_STATS (sim_Com_5_100k_cov40)         [100%] 2 of 2, cached: 2 ✔
[bc/57f702] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:GETSEQKITK (sim_Com_5_10k_cov60)            [100%] 2 of 2, cached: 2 ✔
[39/41d5d8] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MEGAHIT_MANUAL (sim_Com_5_10k_cov60)        [100%] 2 of 2, cached: 2 ✔
[13/6f61e9] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MEGAHIT_KMERGENIE (sim_Com_5_100k_cov40)    [100%] 2 of 2, cached: 2 ✔
[68/8f23a3] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MEGAHIT_READS_LENGTH (sim_Com_5_100k_cov40) [100%] 2 of 2, cached: 2 ✔
[98/9501c9] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:RENAME_ASSEMBLIES (sim_Com_5_100k_cov40)    [100%] 6 of 6, cached: 6 ✔
[f0/562908] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:BUSCO_BUSCO (sim_Com_5_100k_cov40)          [100%] 6 of 6, cached: 6 ✔
[47/c14457] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:BUSCO_SPECIFIC (sim_Com_5_100k_cov40)       [100%] 6 of 6, cached: 6 ✔
[a9/c8bc5a] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MERQURYFK_MERQURYFK (sim_Com_5_100k_cov40)  [100%] 6 of 6, cached: 6 ✔
[c6/31f6af] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:QUAST (sim_Com_5_100k_cov40)                [100%] 2 of 2 ✔
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:CONTAMINATION_DETECTION:TIARA_TIARA                         -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:CONTAMINATION_DETECTION:FCSGX_RUNGX                         -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:CONTAMINATION_DETECTION:CONVERTFCSRPT                       -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:CONTAMINATION_DETECTION:COMPARISON                          -
[c4/831302] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:MULTIQC (multiqc_report)                                    [100%] 1 of 1 ✔
-[nf-core/fspassemblypipeline] Pipeline completed successfully-
```

```
nextflow run . -profile test,docker --outdir results --input assets/samplesheet_assembly.csv -resume --skip_sparseassembler --skip_megahit

executor >  local (3)
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FALCO_RAW                                    -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FASTP_TRIM                                   -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FASTP_MERGE                                  -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FALCO_AFTER_FASTP                            -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FALCO_AFTER_MERGE                            -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FALCO_QCSTAT_COMPILING                       -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FQSTAT                                       -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FQSTAT_SUMMARY                               -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FASTK_FASTK                                  -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FASTK_HISTEX                                 -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:GENESCOPEFK_P1                               -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:GENESCOPEFK_P2                               -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:KMER_STAT_SUMMARY                            -
[14/df7f91] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:FASTK_FASTK (sim_Com_5_100k_cov40)         [100%] 2 of 2, cached: 2 ✔
[25/f48fa0] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:KMERGENIE (sim_Com_5_10k_cov60)            [100%] 2 of 2, cached: 2 ✔
[16/17a5be] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:GETKMERGENIEK (sim_Com_5_100k_cov40)       [100%] 2 of 2, cached: 2 ✔
[1d/d320e5] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:SEQKIT_STATS (sim_Com_5_100k_cov40)        [100%] 2 of 2, cached: 2 ✔
[bc/57f702] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:GETSEQKITK (sim_Com_5_10k_cov60)           [100%] 2 of 2, cached: 2 ✔
[6a/5847da] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:SPADES_MANUAL (sim_Com_5_10k_cov60)        [100%] 2 of 2, cached: 2 ✔
[c7/3e2079] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:SPADES_KMERGENIE (sim_Com_5_10k_cov60)     [100%] 2 of 2, cached: 2 ✔
[c5/fd3708] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:SPADES_READS_LENGTH (sim_Com_5_10k_cov60)  [100%] 2 of 2, cached: 2 ✔
[d6/30bc64] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MINIA_MANUAL (sim_Com_5_10k_cov60)         [100%] 2 of 2, cached: 2 ✔
[0e/41a9f1] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MINIA_KMERGENIE (sim_Com_5_100k_cov40)     [100%] 2 of 2, cached: 2 ✔
[f2/b87a06] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MINIA_READS_LENGTH (sim_Com_5_10k_cov60)   [100%] 2 of 2, cached: 2 ✔
[79/9d25d8] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:ABYSS_MANUAL (sim_Com_5_100k_cov40)        [100%] 2 of 2, cached: 2 ✔
[9f/f4d0d2] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:ABYSS_KMERGENIE (sim_Com_5_100k_cov40)     [100%] 2 of 2, cached: 2 ✔
[0b/2ba56c] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:ABYSS_READS_LENGTH (sim_Com_5_100k_cov40)  [100%] 2 of 2, cached: 2 ✔
[1b/741ee7] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:RENAME_ASSEMBLIES (sim_Com_5_100k_cov40)   [100%] 18 of 18, cached: 18 ✔
[37/9d564f] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:BUSCO_BUSCO (sim_Com_5_10k_cov60)          [100%] 18 of 18, cached: 18 ✔
[c0/1e3de2] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:BUSCO_SPECIFIC (sim_Com_5_10k_cov60)       [100%] 18 of 18, cached: 18 ✔
[da/40a845] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MERQURYFK_MERQURYFK (sim_Com_5_10k_cov60)  [100%] 18 of 18, cached: 18 ✔
[50/129d22] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:QUAST (sim_Com_5_10k_cov60)                [100%] 2 of 2 ✔
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:CONTAMINATION_DETECTION:TIARA_TIARA                        -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:CONTAMINATION_DETECTION:FCSGX_RUNGX                        -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:CONTAMINATION_DETECTION:CONVERTFCSRPT                      -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:CONTAMINATION_DETECTION:COMPARISON                         -
[f2/b9361e] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:MULTIQC (multiqc_report)                                   [100%] 1 of 1 ✔
-[nf-core/fspassemblypipeline] Pipeline completed successfully-
```

```
nextflow run . -profile test,docker --outdir results --input assets/samplesheet_assembly.csv -resume --skip_sparseassembler --skip_manual_strategy

executor >  local (3)
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FALCO_RAW                                    -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FASTP_TRIM                                   -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FASTP_MERGE                                  -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FALCO_AFTER_FASTP                            -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FALCO_AFTER_MERGE                            -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FALCO_QCSTAT_COMPILING                       -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FQSTAT                                       -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FQSTAT_SUMMARY                               -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FASTK_FASTK                                  -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FASTK_HISTEX                                 -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:GENESCOPEFK_P1                               -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:GENESCOPEFK_P2                               -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:KMER_STAT_SUMMARY                            -
[14/df7f91] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:FASTK_FASTK (sim_Com_5_100k_cov40)         [100%] 2 of 2, cached: 2 ✔
[25/f48fa0] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:KMERGENIE (sim_Com_5_10k_cov60)            [100%] 2 of 2, cached: 2 ✔
[0a/a9c300] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:GETKMERGENIEK (sim_Com_5_10k_cov60)        [100%] 2 of 2, cached: 2 ✔
[60/d3c374] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:SEQKIT_STATS (sim_Com_5_10k_cov60)         [100%] 2 of 2, cached: 2 ✔
[5f/bb1182] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:GETSEQKITK (sim_Com_5_100k_cov40)          [100%] 2 of 2, cached: 2 ✔
[a9/f7c109] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:SPADES_KMERGENIE (sim_Com_5_100k_cov40)    [100%] 2 of 2, cached: 2 ✔
[c5/fd3708] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:SPADES_READS_LENGTH (sim_Com_5_10k_cov60)  [100%] 2 of 2, cached: 2 ✔
[d4/e1862a] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MEGAHIT_KMERGENIE (sim_Com_5_10k_cov60)    [100%] 2 of 2, cached: 2 ✔
[48/ba89c3] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MEGAHIT_READS_LENGTH (sim_Com_5_10k_cov60) [100%] 2 of 2, cached: 2 ✔
[0e/41a9f1] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MINIA_KMERGENIE (sim_Com_5_100k_cov40)     [100%] 2 of 2, cached: 2 ✔
[f2/b87a06] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MINIA_READS_LENGTH (sim_Com_5_10k_cov60)   [100%] 2 of 2, cached: 2 ✔
[9f/f4d0d2] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:ABYSS_KMERGENIE (sim_Com_5_100k_cov40)     [100%] 2 of 2, cached: 2 ✔
[25/c2efbc] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:ABYSS_READS_LENGTH (sim_Com_5_10k_cov60)   [100%] 2 of 2, cached: 2 ✔
[94/e55515] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:RENAME_ASSEMBLIES (sim_Com_5_10k_cov60)    [100%] 16 of 16, cached: 16 ✔
[37/9d564f] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:BUSCO_BUSCO (sim_Com_5_10k_cov60)          [100%] 16 of 16, cached: 16 ✔
[4e/616575] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:BUSCO_SPECIFIC (sim_Com_5_10k_cov60)       [100%] 16 of 16, cached: 16 ✔
[a9/3059bb] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MERQURYFK_MERQURYFK (sim_Com_5_10k_cov60)  [100%] 16 of 16, cached: 16 ✔
[c7/0ac508] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:QUAST (sim_Com_5_10k_cov60)                [100%] 2 of 2 ✔
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:CONTAMINATION_DETECTION:TIARA_TIARA                        -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:CONTAMINATION_DETECTION:FCSGX_RUNGX                        -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:CONTAMINATION_DETECTION:CONVERTFCSRPT                      -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:CONTAMINATION_DETECTION:COMPARISON                         -
[71/f9a1be] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:MULTIQC (multiqc_report)                                   [100%] 1 of 1 ✔
-[nf-core/fspassemblypipeline] Pipeline completed successfully-
```

```
nextflow run . -profile test,docker --outdir results --input assets/samplesheet_assembly.csv -resume --skip_sparseassembler --skip_manual_strategy --skip_kmergenie_strategy

executor >  local (3)
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FALCO_RAW                                     -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FASTP_TRIM                                    -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FASTP_MERGE                                   -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FALCO_AFTER_FASTP                             -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FALCO_AFTER_MERGE                             -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FALCO_QCSTAT_COMPILING                        -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FQSTAT                                        -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FQSTAT_SUMMARY                                -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FASTK_FASTK                                   -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:FASTK_HISTEX                                  -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:GENESCOPEFK_P1                                -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:GENESCOPEFK_P2                                -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:PREPROCESSING:KMER_STAT_SUMMARY                             -
[14/df7f91] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:FASTK_FASTK (sim_Com_5_100k_cov40)          [100%] 2 of 2, cached: 2 ✔
[60/d3c374] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:SEQKIT_STATS (sim_Com_5_10k_cov60)          [100%] 2 of 2, cached: 2 ✔
[bc/57f702] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:GETSEQKITK (sim_Com_5_10k_cov60)            [100%] 2 of 2, cached: 2 ✔
[c5/fd3708] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:SPADES_READS_LENGTH (sim_Com_5_10k_cov60)   [100%] 2 of 2, cached: 2 ✔
[68/8f23a3] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MEGAHIT_READS_LENGTH (sim_Com_5_100k_cov40) [100%] 2 of 2, cached: 2 ✔
[f2/b87a06] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MINIA_READS_LENGTH (sim_Com_5_10k_cov60)    [100%] 2 of 2, cached: 2 ✔
[25/c2efbc] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:ABYSS_READS_LENGTH (sim_Com_5_10k_cov60)    [100%] 2 of 2, cached: 2 ✔
[84/165192] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:RENAME_ASSEMBLIES (sim_Com_5_10k_cov60)     [100%] 8 of 8, cached: 8 ✔
[2f/cdef01] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:BUSCO_BUSCO (sim_Com_5_100k_cov40)          [100%] 8 of 8, cached: 8 ✔
[e9/c5f9a3] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:BUSCO_SPECIFIC (sim_Com_5_100k_cov40)       [100%] 8 of 8, cached: 8 ✔
[a3/b8ab39] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:MERQURYFK_MERQURYFK (sim_Com_5_100k_cov40)  [100%] 8 of 8, cached: 8 ✔
[a5/d722d0] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:GENOME_ASSEMBLY:QUAST (sim_Com_5_10k_cov60)                 [100%] 2 of 2 ✔
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:CONTAMINATION_DETECTION:TIARA_TIARA                         -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:CONTAMINATION_DETECTION:FCSGX_RUNGX                         -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:CONTAMINATION_DETECTION:CONVERTFCSRPT                       -
[-        ] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:CONTAMINATION_DETECTION:COMPARISON                          -
[82/7a6106] NFCORE_FSPASSEMBLYPIPELINE:FSPASSEMBLYPIPELINE:MULTIQC (multiqc_report)                                    [100%] 1 of 1 ✔
-[nf-core/fspassemblypipeline] Pipeline completed successfully-
```

Let me know if there is anything to change or improve!

<!--
# nf-core/fspassemblypipeline pull request

Many thanks for contributing to nf-core/fspassemblypipeline!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/fspassemblypipeline/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/fspassemblypipeline/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/fspassemblypipeline _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
